### PR TITLE
feat(team): 更新 `team.members` 資料結構以管理邀請與權限

### DIFF
--- a/app/(protected)/team/[teamId]/members/[memberId]/edit/page.jsx
+++ b/app/(protected)/team/[teamId]/members/[memberId]/edit/page.jsx
@@ -1,35 +1,9 @@
-"use client";
-import { useRouter } from "next/navigation";
-import { useTeamMembers } from "@/hooks/use-data";
-import MemberForm from "@/components/team/members/form";
+import InfoForm from "@/components/team/members/info-form";
 
 const EditMemberPage = ({ params }) => {
-  const router = useRouter();
   const { teamId, memberId } = params;
-  const { members, mutate } = useTeamMembers(teamId);
-  const member = members?.find((member) => member._id === memberId) || {};
 
-  const onSubmit = async (formData) => {
-    formData.team_id = teamId;
-    try {
-      const res = await fetch(`/api/members/${memberId}`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(formData),
-      });
-      const member = await res.json();
-      const memberIndex = members.findIndex(
-        (member) => member._id === memberId
-      );
-      members[memberIndex] = member;
-      mutate([...members], false);
-      return router.push(`/team/${teamId}/members/${memberId}`);
-    } catch (error) {
-      console.error(error);
-    }
-  };
-
-  return <MemberForm member={member} onSubmit={onSubmit} className="w-full" />;
+  return <InfoForm teamId={teamId} memberId={memberId} className="w-full" />;
 };
 
 export default EditMemberPage;

--- a/app/(protected)/team/[teamId]/members/new/page.jsx
+++ b/app/(protected)/team/[teamId]/members/new/page.jsx
@@ -1,30 +1,9 @@
-"use client";
-import { useRouter } from "next/navigation";
-import { useTeamMembers } from "@/hooks/use-data";
 import MemberForm from "@/components/team/members/form";
 
 const MemberCreatePage = ({ params }) => {
-  const router = useRouter();
   const { teamId } = params;
-  const { members, mutate } = useTeamMembers(teamId);
 
-  const onSubmit = async (formData) => {
-    formData.team_id = teamId;
-    try {
-      const res = await fetch("/api/members", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(formData),
-      });
-      const member = await res.json();
-      mutate([...members, member], false);
-      return router.push(`/team/${teamId}/members/${member._id}`);
-    } catch (error) {
-      console.error(error);
-    }
-  };
-
-  return <MemberForm onSubmit={onSubmit} className="w-full" />;
+  return <MemberForm teamId={teamId} className="w-full" />;
 };
 
 export default MemberCreatePage;

--- a/app/api/teams/[teamId]/members/route.js
+++ b/app/api/teams/[teamId]/members/route.js
@@ -1,15 +1,95 @@
 import { NextResponse } from "next/server";
-import connectMongoDB from "@/app/api/utils/connect-mongodb";
+import { auth } from "@/auth";
+import connectToMongoDB from "@/lib/connect-to-mongodb";
+import User from "@/app/models/user";
+import Team from "@/app/models/team";
 import Member from "@/app/models/member";
 
 export const GET = async (req, { params }) => {
   try {
     const { teamId } = params;
-    await connectMongoDB();
+    await connectToMongoDB();
     const members = await Member.find({ team_id: teamId });
     return NextResponse.json(members, { status: 200 });
   } catch (error) {
     console.log("[get-team-members]", error);
+    return NextResponse.json({ error }, { status: 500 });
+  }
+};
+
+export const PATCH = async (req, { params }) => {
+  try {
+    const session = await auth();
+    if (!session) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    await connectToMongoDB();
+    const user = await User.findById(session.user._id);
+    if (!user) {
+      return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+
+    const { teamId } = params;
+    const team = await Team.findById(teamId);
+    if (!team) {
+      return NextResponse.json({ error: "Team not found" }, { status: 404 });
+    }
+    const { members } = team;
+
+    const searchParams = req.nextUrl.searchParams;
+    const memberId = searchParams.get("memberId");
+    const action = searchParams.get("action");
+    const formData = await req.json();
+
+    const memberIndex = members.findIndex((m) => m._id.toString() === memberId);
+    if (memberIndex === -1) {
+      return NextResponse.json({ error: "Member not found" }, { status: 404 });
+    }
+    const member = members[memberIndex];
+
+    if (action === "invite") {
+      if (member?.email === formData.email) {
+        return NextResponse.json(team.members, { status: 200 });
+      }
+
+      if (member?.user_id) {
+        const leavingUser = await User.findById(member.user_id);
+        if (leavingUser) {
+          leavingUser.teams.joined = leavingUser.teams.joined.filter(
+            (t) => t.toString() !== teamId
+          );
+          await leavingUser.save();
+        }
+        team.members[memberIndex].user_id = null;
+        team.members[memberIndex].email = "";
+      } else if (member?.email) {
+        const leavingUser = await User.findOne({ email: member.email });
+        if (leavingUser) {
+          leavingUser.teams.inviting = leavingUser.teams.inviting.filter(
+            (t) => t.toString() !== teamId
+          );
+          await leavingUser.save();
+        }
+        team.members[memberIndex].email = "";
+      }
+
+      if (formData.email) {
+        const invitingUser = await User.findOne({ email: formData.email });
+        if (invitingUser) {
+          invitingUser.teams.inviting.push(teamId);
+          await invitingUser.save();
+        }
+        team.members[memberIndex].email = formData.email;
+      }
+    } else if (action === "access") {
+      team.members[memberIndex].role = formData.role;
+    }
+
+    await team.save();
+    return NextResponse.json(team.members, { status: 200 });
+  } catch (error) {
+    console.log("[patch-team-members]", error);
     return NextResponse.json({ error }, { status: 500 });
   }
 };

--- a/app/api/teams/route.js
+++ b/app/api/teams/route.js
@@ -20,11 +20,6 @@ export const POST = async (req) => {
     }
 
     const newMember = new Member({
-      meta: {
-        admin: true,
-        email: user.email,
-        user_id: user._id,
-      },
       name: user.name,
       number: 1,
     });
@@ -36,7 +31,14 @@ export const POST = async (req) => {
     const newTeam = new Team({
       name,
       nickname,
-      members: [newMember._id],
+      members: [
+        {
+          _id: newMember._id,
+          user_id: user._id,
+          email: user.email,
+          role: "owner",
+        },
+      ],
       lineups: new Array(3).fill({
         config: {
           liberoMode: 0,

--- a/app/models/member.js
+++ b/app/models/member.js
@@ -10,7 +10,6 @@ const memberSchema = new Schema(
     meta: {
       admin: {
         type: Boolean,
-        required: true,
       },
       email: {
         type: String,

--- a/app/models/team.js
+++ b/app/models/team.js
@@ -10,60 +10,35 @@ const teamSchema = new Schema(
       type: String,
     },
     members: [
-      // TODO: 待前端 members 狀態從 team 獨立後，刪除此欄位
-      // 以四種 lineup 名單代替
       {
-        type: Schema.Types.ObjectId,
-        ref: "Member",
-        required: true,
+        _id: { type: Schema.Types.ObjectId, ref: "Member" },
+        user_id: { type: Schema.Types.ObjectId, ref: "User" },
+        email: { type: String },
+        role: { type: String, enum: ["owner", "admin", "member"] },
       },
     ],
     lineups: [
       {
         config: {
-          liberoMode: {
-            type: Number,
-            enum: [0, 1, 2],
+          liberoMode: { type: Number, enum: [0, 1, 2] },
+        },
+        starting: [
+          {
+            _id: { type: Schema.Types.ObjectId, ref: "Member" },
+            position: { type: String, enum: ["OH", "MB", "OP", "S"] },
           },
-        },
-        starting: {
-          type: [
-            {
-              _id: {
-                type: Schema.Types.ObjectId,
-                ref: "Member",
-              },
-              position: {
-                type: String,
-                enum: ["OH", "MB", "OP", "S"],
-              },
-            },
-          ],
-        },
-        liberos: {
-          type: [
-            {
-              _id: {
-                type: Schema.Types.ObjectId,
-                ref: "Member",
-              },
-              position: {
-                type: String,
-                enum: ["L"],
-              },
-            },
-          ],
-        },
-        substitutes: {
-          type: [
-            {
-              _id: {
-                type: Schema.Types.ObjectId,
-                ref: "Member",
-              },
-            },
-          ],
-        },
+        ],
+        liberos: [
+          {
+            _id: { type: Schema.Types.ObjectId, ref: "Member" },
+            position: { type: String, enum: ["L"] },
+          },
+        ],
+        substitutes: [
+          {
+            _id: { type: Schema.Types.ObjectId, ref: "Member" },
+          },
+        ],
       },
     ],
     matches: [

--- a/components/team/members/access-config/email-form.jsx
+++ b/components/team/members/access-config/email-form.jsx
@@ -1,0 +1,108 @@
+"use client";
+import { z } from "zod";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useToast } from "@/components/ui/use-toast";
+import { useTeam } from "@/hooks/use-data";
+import { FiSend } from "react-icons/fi";
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+
+const formSchema = z.object({
+  email: z
+    .string()
+    .email({ message: "請輸入有效的 email" })
+    .optional()
+    .or(z.literal("")),
+});
+
+const EmailForm = ({ teamId, memberId }) => {
+  const { toast } = useToast();
+  const { team, mutate } = useTeam(teamId);
+  const member = team?.members?.find((member) => member._id === memberId);
+  const form = useForm({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      email: member?.email || "",
+    },
+  });
+
+  const onSubmit = async (formData) => {
+    const isEmailNotChanged = formData.email === member?.email;
+    if (isEmailNotChanged) {
+      return toast({
+        title: "email 未變更",
+        description: "已邀請此 email 加入隊伍",
+      });
+    }
+
+    const hasSameEmail = team.members.some((m) => m?.email === formData.email);
+    if (hasSameEmail) {
+      form.setError("email", {
+        message: "已在其他成員邀請中使用此 email",
+      });
+      return toast({
+        title: "email 已存在",
+        description: "已在其他成員邀請中使用此 email",
+        variant: "destructive",
+      });
+    }
+
+    try {
+      const res = await fetch(
+        `/api/teams/${teamId}/members?memberId=${memberId}&action=invite`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(formData),
+        }
+      );
+      const members = await res.json();
+      mutate({ ...team, members }, false);
+
+      if (!formData.email) return toast({ title: "已移除 email" });
+
+      return toast({
+        title: "邀請已發送",
+        description: "受邀者將在以此 email 註冊之帳號收到邀請",
+      });
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  return (
+    <Form form={form} onSubmit={form.handleSubmit(onSubmit)}>
+      {/* TODO: 顯示已接受要請之使用者 */}
+      <FormField
+        control={form.control}
+        name="email"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>電子郵件</FormLabel>
+            <FormControl>
+              <Input placeholder="v-stats@example.com" {...field} />
+            </FormControl>
+            <FormDescription>
+              受邀者將在以此 email 註冊之帳號收到邀請
+            </FormDescription>
+          </FormItem>
+        )}
+      />
+      <Button type="submit" variant="destructive" size="lg">
+        <FiSend />
+        發送隊伍邀請
+      </Button>
+    </Form>
+  );
+};
+
+export default EmailForm;

--- a/components/team/members/access-config/index.jsx
+++ b/components/team/members/access-config/index.jsx
@@ -1,0 +1,17 @@
+import { CardHeader, CardTitle } from "@/components/ui/card";
+import EmailForm from "@/components/team/members/access-config/email-form";
+import RoleForm from "@/components/team/members/access-config/role-form";
+
+const AccessConfig = ({ teamId, memberId }) => {
+  return (
+    <>
+      <CardHeader className="mt-4">
+        <CardTitle>邀請與權限</CardTitle>
+      </CardHeader>
+      <EmailForm teamId={teamId} memberId={memberId} />
+      <RoleForm teamId={teamId} memberId={memberId} />
+    </>
+  );
+};
+
+export default AccessConfig;

--- a/components/team/members/access-config/role-form.jsx
+++ b/components/team/members/access-config/role-form.jsx
@@ -1,0 +1,92 @@
+"use client";
+import { z } from "zod";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useTeam } from "@/hooks/use-data";
+import { FiSave, FiUser, FiShield } from "react-icons/fi";
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+} from "@/components/ui/form";
+import {
+  Select,
+  SelectTrigger,
+  SelectItem,
+  SelectValue,
+  SelectContent,
+} from "@/components/ui/select";
+
+const formSchema = z.object({
+  role: z.enum(["owner", "admin", "member"]),
+});
+
+const RoleForm = ({ teamId, memberId }) => {
+  const { team, mutate } = useTeam(teamId);
+  const member = team?.members?.find((member) => member._id === memberId);
+  const form = useForm({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      role: member?.role || "member",
+    },
+  });
+
+  const onSubmit = async (formData) => {
+    try {
+      const res = await fetch(
+        `/api/teams/${teamId}/members?memberId=${memberId}&action=access`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(formData),
+        }
+      );
+      const members = await res.json();
+      mutate({ ...team, members }, false);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  return (
+    <Form form={form} onSubmit={form.handleSubmit(onSubmit)} className="mt-4">
+      <FormField
+        control={form.control}
+        name="role"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>權限</FormLabel>
+            <Select onValueChange={field.onChange} defaultValue={field.value}>
+              <FormControl>
+                <SelectTrigger>
+                  <SelectValue placeholder="選擇權限" />
+                </SelectTrigger>
+              </FormControl>
+              <SelectContent>
+                <SelectItem value="member">
+                  <FiUser />
+                  一般成員
+                </SelectItem>
+                <SelectItem value="admin">
+                  <FiShield />
+                  管理者
+                </SelectItem>
+              </SelectContent>
+            </Select>
+            <FormDescription>管理者有權限變更隊伍與成員資訊，以及權限設定</FormDescription>
+          </FormItem>
+        )}
+      />
+      <Button type="submit" variant="destructive" size="lg">
+        <FiSave />
+        儲存權限設定
+      </Button>
+    </Form>
+  );
+};
+
+export default RoleForm;

--- a/components/team/members/info-form.jsx
+++ b/components/team/members/info-form.jsx
@@ -1,0 +1,111 @@
+"use client";
+import { useRouter } from "next/navigation";
+import { useTeamMembers } from "@/hooks/use-data";
+import { z } from "zod";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { FiSave } from "react-icons/fi";
+import { Button } from "@/components/ui/button";
+import { Card, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import LoadingCard from "@/components/custom/loading/card";
+
+const formSchema = z.object({
+  name: z.string().min(1, { message: "姓名不得為空" }),
+  number: z.coerce
+    .number()
+    .min(1, { message: "背號不得為空或小於 1" })
+    .max(99, { message: "背號不得大於 99" }),
+});
+
+const MemberInfoForm = ({ member, onSubmit }) => {
+  const form = useForm({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      name: member?.name || "",
+      number: member?.number || "",
+    },
+  });
+
+  return (
+    <Form form={form} onSubmit={form.handleSubmit(onSubmit)} className="mt-4">
+      <FormField
+        control={form.control}
+        name="name"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel required>姓名</FormLabel>
+            <FormControl>
+              <Input placeholder="石川祐希" {...field} />
+            </FormControl>
+          </FormItem>
+        )}
+      />
+      <FormField
+        control={form.control}
+        name="number"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel required>背號</FormLabel>
+            <FormControl>
+              <Input
+                placeholder="14"
+                type="number"
+                inputMode="numeric"
+                {...field}
+              />
+            </FormControl>
+          </FormItem>
+        )}
+      />
+      <Button size="lg">
+        <FiSave />
+        儲存成員資訊
+      </Button>
+    </Form>
+  );
+};
+
+const InfoForm = ({ teamId, memberId, className }) => {
+  const router = useRouter();
+  const { members, mutate } = useTeamMembers(teamId);
+  const member = members?.find((member) => member._id === memberId) || {};
+
+  const onSubmit = async (formData) => {
+    formData.team_id = teamId;
+    try {
+      const res = await fetch(`/api/members/${memberId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(formData),
+      });
+      const member = await res.json();
+      const memberIndex = members.findIndex((m) => m._id === memberId);
+      members[memberIndex] = member;
+      mutate([...members], false);
+      return router.push(`/team/${teamId}/members/${memberId}`);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  if (!members) return <LoadingCard className={className} />;
+
+  return (
+    <Card className={className}>
+      <CardHeader>
+        <CardTitle>基本資訊</CardTitle>
+      </CardHeader>
+      <MemberInfoForm member={member} onSubmit={onSubmit} />
+    </Card>
+  );
+};
+
+export default InfoForm;

--- a/components/team/members/info/index.jsx
+++ b/components/team/members/info/index.jsx
@@ -1,20 +1,56 @@
 "use client";
+import Image from "next/image";
 import { useTeam, useTeamMembers } from "@/hooks/use-data";
-import { Card } from "@/components/ui/card";
+import { FiUser } from "react-icons/fi";
+import { Link } from "@/components/ui/button";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardBtnGroup,
+} from "@/components/ui/card";
 import MembersInfoTable from "@/components/team/members/info/table";
+import AccessConfig from "@/components/team/members/access-config";
+import LoadingCard from "@/components/custom/loading/card";
 
 const MembersInfo = ({ teamId, memberId, className }) => {
   const { team } = useTeam(teamId);
-  const { members, isLoading } = useTeamMembers(teamId);
+  const { members } = useTeamMembers(teamId);
   const member = members?.find((member) => member._id === memberId) || {};
+  const isAdmin = true;
+  // TODO: 更新 admin 資料結構
+
+  if (!team || !members) return <LoadingCard className={className} />;
 
   return (
     <Card className={className}>
-      {isLoading ? (
-        <>Loading...</>
-      ) : (
-        <MembersInfoTable team={team} member={member} />
-      )}
+      <CardHeader className="h-fit">
+        {member?.image ? (
+          <Image
+            src={member.image}
+            alt={member.name}
+            width={64}
+            height={64}
+            className="rounded-full"
+          />
+        ) : (
+          <FiUser className="w-16 h-16 rounded-full text-muted-foreground" />
+        )}
+        <CardTitle>{member.name}</CardTitle>
+        {isAdmin && (
+          <CardBtnGroup>
+            <Link
+              variant="link"
+              size="lg"
+              href={`/team/${teamId}/members/${memberId}/edit`}
+            >
+              編輯
+            </Link>
+          </CardBtnGroup>
+        )}
+      </CardHeader>
+      <MembersInfoTable team={team} member={member} />
+      <AccessConfig teamId={teamId} memberId={memberId} />
     </Card>
   );
 };

--- a/components/team/members/info/table.jsx
+++ b/components/team/members/info/table.jsx
@@ -1,53 +1,14 @@
-import {
-  FiHash,
-  FiUser,
-  FiUsers,
-  FiMail,
-  FiShield,
-  FiEdit2,
-} from "react-icons/fi";
-import { Link } from "@/components/ui/button";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
+import { FiHash, FiUsers } from "react-icons/fi";
+import { Table, TableBody, TableCell, TableRow } from "@/components/ui/table";
 
 const MembersInfoTable = ({ team, member, className }) => {
   const contents = [
     { key: "隊伍", value: team?.name, icon: <FiUsers /> },
     { key: "背號", value: member?.number, icon: <FiHash /> },
-    { key: "姓名", value: member?.name, icon: <FiUser /> },
-    { key: "信箱", value: member?.meta?.email, icon: <FiMail /> },
-    {
-      key: "權限",
-      value: member?.meta?.admin ? "管理者" : "一般成員",
-      icon: <FiShield />,
-    },
   ];
-  const isAdmin = true;
-  // TODO: 更新 admin 資料結構
 
   return (
     <Table className={className}>
-      <TableHeader className="text-lg">
-        <TableRow>
-          <TableHead colSpan={2}>成員資訊</TableHead>
-          <TableHead className="flex justify-end">
-            {isAdmin && (
-              <Link
-                variant="ghost"
-                href={`/team/${team._id}/members/${member._id}/edit`}
-              >
-                <FiEdit2 />
-              </Link>
-            )}
-          </TableHead>
-        </TableRow>
-      </TableHeader>
       <TableBody className="text-xl">
         {contents.map(({ key, value, icon }) => (
           <TableRow key={key}>


### PR DESCRIPTION
變動內容：
1. 將 `email`, `user_id`, `role` 欄位移至 team.members 資料結構
2. 修改 `POST /api/members` 新增成員 API，新增成員同時會建立 team.members 資料
3. 修改 `POST /api/teams` 新增球隊 API，修改新增球隊時薪成員的資料結構
4. `PUT /api/members/:memberId -> PATCH /api/members/:memberId`, 修改成員資料 API 僅能修改基本資料，無法修改邀請與權限
5. 新增 `PATCH /api/teams/${teamId}/members?memberId=${memberId}&action=${action}` 以處理成員邀請與權限設定