### PR TITLE
fix(auth): 修正 google 登入無法切換帳號的問題

### DIFF
--- a/auth.config.js
+++ b/auth.config.js
@@ -7,6 +7,9 @@ const authConfig = {
     Google({
       clientId: process.env.AUTH_GOOGLE_ID,
       clientSecret: process.env.AUTH_GOOGLE_SECRET,
+      authorization: {
+        params: { prompt: "select_account" },
+      },
     }),
   ],
   events: {


### PR DESCRIPTION
問題描述：
在 standalone pwa 進行 google oauth 登入時，
都會跳過選擇 google 帳戶頁面直接使用先前的帳號登入，
讓使用者無法選擇其他 google 帳號。
在一般瀏覽器使用下則不會出現此問題。

解決方法：
在 `auth.config.js` 中加入 `prompt: 'select_account'`，
強制 google 登入頁面顯示選擇帳號的頁面。