### PR TITLE
fix(team): libero-switch form 預設值無法隨陣容配置組合改變問題(#76)

### DIFF
--- a/components/team/lineup/panels/options/libero-switch.jsx
+++ b/components/team/lineup/panels/options/libero-switch.jsx
@@ -1,4 +1,5 @@
 "use client";
+import { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { lineupsActions } from "@/app/store/lineups-slice";
 import { z } from "zod";
@@ -63,6 +64,13 @@ const LiberoSwitch = () => {
       position: liberoSwitchPosition,
     },
   });
+
+  useEffect(() => {
+    form.reset({
+      mode: liberoSwitchMode.toString(),
+      position: liberoSwitchPosition,
+    });
+  }, [form, liberoSwitchMode, liberoSwitchPosition]);
 
   const onSubmit = (formData) => {
     dispatch(


### PR DESCRIPTION
使用 `react-hook-form` [reset](https://react-hook-form.com/docs/useform/reset) api 與 `useEffect` 監測預設值變化進行預設值重置。