### PR TITLE
feat: replace `rallies` with `entries` in record

### DIFF
--- a/src/app/api/records/[recordId]/route.ts
+++ b/src/app/api/records/[recordId]/route.ts
@@ -34,5 +34,3 @@ export const GET = async (
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
 };
-
-// TODO: 新增上場選手對應局數的 stats 物件（在開新局、換人時）

--- a/src/app/api/records/[recordId]/sets/rallies/route.ts
+++ b/src/app/api/records/[recordId]/sets/rallies/route.ts
@@ -11,15 +11,15 @@ export const POST = async (
     const rally = await req.json();
     const searchParams = req.nextUrl.searchParams;
     const setIndex = parseInt(searchParams.get("si") || "0", 10);
-    const rallyIndex = parseInt(searchParams.get("ri") || "0", 10);
+    const entryIndex = parseInt(searchParams.get("ei") || "0", 10);
 
-    const rallies = await createRallyController({
-      params: { recordId, setIndex, rallyIndex },
+    const entries = await createRallyController({
+      params: { recordId, setIndex, entryIndex },
       data: rally,
     });
-    return NextResponse.json(rallies, { status: 200 });
+    return NextResponse.json(entries, { status: 200 });
   } catch (error) {
-    console.log("[POST /api/records]", error);
+    console.log("[POST /api/records/sets/rallies]", error);
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
 };

--- a/src/app/api/records/[recordId]/sets/substitutions/route.ts
+++ b/src/app/api/records/[recordId]/sets/substitutions/route.ts
@@ -11,13 +11,13 @@ export const POST = async (
     const substitution = await req.json();
     const searchParams = req.nextUrl.searchParams;
     const setIndex = parseInt(searchParams.get("si") || "0", 10);
-    const rallyIndex = parseInt(searchParams.get("ri") || "0", 10);
+    const entryIndex = parseInt(searchParams.get("ei") || "0", 10);
 
-    const substitutions = await createSubstitutionController({
-      params: { recordId, setIndex, rallyIndex },
+    const entries = await createSubstitutionController({
+      params: { recordId, setIndex, entryIndex },
       data: substitution,
     });
-    return NextResponse.json(substitutions, { status: 200 });
+    return NextResponse.json(entries, { status: 200 });
   } catch (error) {
     console.log("[POST /api/records/sets/substitutions]", error);
     return NextResponse.json({ error: error.message }, { status: 500 });

--- a/src/applications/use-cases/record/create-set.use-case.ts
+++ b/src/applications/use-cases/record/create-set.use-case.ts
@@ -74,10 +74,7 @@ export class CreateSetUseCase {
       win: null,
       lineups: { home: data.lineup },
       options: data.options,
-      rallies: [],
-      substitutions: [],
-      timeouts: [],
-      challenges: [],
+      entries: [],
     };
 
     const updatedRecord = await this.recordRepository.update(

--- a/src/applications/use-cases/record/create-substitution.use-case.ts
+++ b/src/applications/use-cases/record/create-substitution.use-case.ts
@@ -3,15 +3,20 @@ import { ITeamRepository } from "@/applications/repositories/team.repository.int
 import { IRecordRepository } from "@/applications/repositories/record.repository.interface";
 import { AuthenticationService } from "@/infrastructure/service/auth/authentication.service";
 import { AuthorizationService } from "@/infrastructure/service/auth/authorization.service";
-import { type Substitution, Side } from "@/entities/record";
+import {
+  type Substitution,
+  Side,
+  EntryType,
+  type Entry,
+} from "@/entities/record";
 import { Role } from "@/entities/team";
 
 export interface ICreateSubstitutionInput {
-  params: { recordId: string; setIndex: number; rallyIndex: number };
+  params: { recordId: string; setIndex: number; entryIndex: number };
   data: Substitution;
 }
 
-export type ICreateSubstitutionOutput = Substitution[];
+export type ICreateSubstitutionOutput = Entry[];
 
 export class CreateSubstitutionUseCase {
   private userRepository: IUserRepository;
@@ -49,7 +54,7 @@ export class CreateSubstitutionUseCase {
       Role.MEMBER
     );
 
-    const { setIndex } = params;
+    const { setIndex, entryIndex } = params;
     const {
       team,
       players: { in: inPlayer, out: outPlayer },
@@ -80,11 +85,14 @@ export class CreateSubstitutionUseCase {
     lineup.starting[startingIndex] = startingPlayer;
     lineup.substitutes[subIndex] = subPlayer;
     record.sets[setIndex].lineups[side] = lineup;
-    record.sets[setIndex].substitutions.push(substitution);
+    record.sets[setIndex].entries[entryIndex] = {
+      type: EntryType.SUBSTITUTION,
+      data: substitution,
+    };
     record.teams[side].stats[setIndex].substitution += 1;
 
     await this.recordRepository.update({ _id: params.recordId }, record);
 
-    return record.sets[setIndex].substitutions;
+    return record.sets[setIndex].entries;
   }
 }

--- a/src/components/record/entry/index.tsx
+++ b/src/components/record/entry/index.tsx
@@ -1,4 +1,13 @@
 import { cn } from "@/lib/utils";
+import Rally from "@/components/record/entry/rally";
+import Substitution from "@/components/record/entry/substitution";
+import {
+  type Player,
+  type Entry as IEntry,
+  EntryType,
+  Rally as RallyType,
+  Substitution as SubstitutionType,
+} from "@/entities/record";
 
 export const EntryContainer = ({
   onClick,
@@ -21,7 +30,7 @@ export const EntryContainer = ({
 );
 
 export const EntryScore = ({
-  win = false,
+  win = null,
   children,
 }: {
   win?: boolean;
@@ -31,8 +40,9 @@ export const EntryScore = ({
     <div
       className={cn(
         "flex items-center justify-center flex-none",
-        "basis-8 w-8 h-8 bg-accent text-[1.5rem] rounded-[0.5rem] font-semibold",
-        win && "bg-primary text-primary-foreground"
+        "basis-8 w-8 h-8 text-[1.5rem] rounded-[0.5rem] font-semibold",
+        win !== null &&
+          (win ? "bg-primary text-primary-foreground" : "bg-accent")
       )}
     >
       {children}
@@ -64,3 +74,30 @@ export const EntryPlayerNumber = ({
 }: {
   children: React.ReactNode;
 }) => <span className="text-[1.375rem] font-semibold">{children}</span>;
+
+const Entry = ({
+  entry,
+  players,
+  onClick,
+  className,
+}: {
+  entry: IEntry;
+  players: Player[];
+  onClick?: () => void;
+  className?: string;
+}) => {
+  return (
+    <EntryContainer onClick={onClick} className={className}>
+      {entry.type === EntryType.RALLY ? (
+        <Rally rally={entry.data as RallyType} players={players} />
+      ) : (
+        <Substitution
+          substitution={entry.data as SubstitutionType}
+          players={players}
+        />
+      )}
+    </EntryContainer>
+  );
+};
+
+export default Entry;

--- a/src/components/record/entry/rally.tsx
+++ b/src/components/record/entry/rally.tsx
@@ -1,6 +1,5 @@
 import { FiPlus, FiMinus, FiUser } from "react-icons/fi";
 import {
-  EntryContainer,
   EntryScore,
   EntryText,
   EntryPlayerNumber,
@@ -13,22 +12,12 @@ const IconWin = () => <FiPlus className="text-primary" />;
 
 const IconLose = () => <FiMinus className="text-destructive" />;
 
-const Rally = ({
-  rally,
-  players,
-  onClick,
-  className,
-}: {
-  rally: Rally;
-  players: Player[];
-  onClick: () => void;
-  className?: string;
-}) => {
+const Rally = ({ rally, players }: { rally: Rally; players: Player[] }) => {
   const { win, home, away } = rally;
   const playerNumber = players.find((p) => p._id === home.player._id)?.number;
 
   return (
-    <EntryContainer className={className} onClick={onClick}>
+    <>
       {home.type ? (
         <>
           <EntryScore win={win}>{home.score}</EntryScore>
@@ -69,7 +58,7 @@ const Rally = ({
             <>--</>
           ))}
       </EntryText>
-    </EntryContainer>
+    </>
   );
 };
 

--- a/src/components/record/entry/substitution.tsx
+++ b/src/components/record/entry/substitution.tsx
@@ -1,5 +1,5 @@
+import { FiChevronUp, FiChevronDown } from "react-icons/fi";
 import {
-  EntryContainer,
   EntryScore,
   EntryText,
   EntryPlayerNumber,
@@ -10,27 +10,29 @@ import { type Substitution, type Player } from "@/entities/record";
 const Substitution = ({
   substitution,
   players,
-  className,
 }: {
   substitution: Substitution;
   players: Player[];
-  className?: string;
 }) => {
   const inPlayer = players.find((p) => p._id === substitution.players.in);
   const outPlayer = players.find((p) => p._id === substitution.players.out);
 
   return (
-    <EntryContainer className={className}>
+    <>
       <EntryScore />
       <EntryScore />
-      <EntryText className="border-primary">
-        <EntryPlayerNumber>{inPlayer.number}</EntryPlayerNumber>
-        IN
-      </EntryText>
-      <EntryText className="border-destructive">
-        <EntryPlayerNumber>{outPlayer.number}</EntryPlayerNumber>
+      <EntryText>
+        <EntryPlayerNumber>{outPlayer?.number}</EntryPlayerNumber>
         OUT
+        <FiChevronDown className="text-destructive" />
       </EntryText>
-    </EntryContainer>
+      <EntryText>
+        <EntryPlayerNumber>{inPlayer?.number}</EntryPlayerNumber>
+        IN
+        <FiChevronUp className="text-primary" />
+      </EntryText>
+    </>
   );
 };
+
+export default Substitution;

--- a/src/components/record/options/edit/index.tsx
+++ b/src/components/record/options/edit/index.tsx
@@ -6,9 +6,9 @@ import { Button } from "@/components/ui/button";
 import { DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import RecordCourt from "@/components/record/court";
 import RecordPreview from "@/components/record/preview";
-import RecordMoves from "@/components/record/panels/moves";
+import RecordPanels from "@/components/record/panels";
 
-const RalliesEdit = ({ recordId }: { recordId: string }) => {
+const EntriesEdit = ({ recordId }: { recordId: string }) => {
   const dispatch = useAppDispatch();
   const editingState = useAppSelector((state) => state.editing);
 
@@ -35,7 +35,7 @@ const RalliesEdit = ({ recordId }: { recordId: string }) => {
         recordState={editingState}
         className="px-0 py-1 shadow-none"
       />
-      <RecordMoves
+      <RecordPanels
         recordId={recordId}
         recordState={editingState}
         recordActions={editingActions}
@@ -45,4 +45,4 @@ const RalliesEdit = ({ recordId }: { recordId: string }) => {
   );
 };
 
-export default RalliesEdit;
+export default EntriesEdit;

--- a/src/components/record/options/index.tsx
+++ b/src/components/record/options/index.tsx
@@ -7,7 +7,7 @@ import {
   DialogDescription,
 } from "@/components/ui/dialog";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import RalliesEdit from "@/components/record/options/edit";
+import EntriesEdit from "@/components/record/options/edit";
 import RecordOptionsOverview from "@/components/record/options/overview";
 import RecordOptionsSummary from "@/components/record/options/summary";
 
@@ -25,13 +25,13 @@ const RecordOptions = ({
   return (
     <DialogContent size="lg">
       {editingState.isEditing ? (
-        <RalliesEdit recordId={recordId} />
+        <EntriesEdit recordId={recordId} />
       ) : (
         <>
           <DialogHeader>
             <DialogTitle>
               {tabValue === "overview" && "數據總覽"}
-              {tabValue === "rallies" && "逐球紀錄"}
+              {tabValue === "summary" && "逐球紀錄"}
               {tabValue === "settings" && "賽事資訊與設定"}
             </DialogTitle>
           </DialogHeader>
@@ -39,13 +39,13 @@ const RecordOptions = ({
           <Tabs value={tabValue} onValueChange={setTabValue}>
             <TabsList className="grid w-full grid-cols-3">
               <TabsTrigger value="overview">總覽</TabsTrigger>
-              <TabsTrigger value="rallies">紀錄</TabsTrigger>
+              <TabsTrigger value="summary">紀錄</TabsTrigger>
               <TabsTrigger value="settings">設定</TabsTrigger>
             </TabsList>
             <TabsContent value="overview" className="flex-1">
               <RecordOptionsOverview recordId={recordId} />
             </TabsContent>
-            <TabsContent value="rallies" className="flex-1 h-full">
+            <TabsContent value="summary" className="flex-1 h-full">
               <RecordOptionsSummary recordId={recordId} />
             </TabsContent>
             <TabsContent value="settings" className="flex-1">

--- a/src/components/record/options/summary.tsx
+++ b/src/components/record/options/summary.tsx
@@ -5,37 +5,17 @@ import { editingActions } from "@/lib/features/record/editing-slice";
 import { FiChevronLeft, FiChevronRight } from "react-icons/fi";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
-import Rally from "@/components/record/entry/rally";
+import Entry from "@/components/record/entry";
 
 const RecordOptionsSummary = ({ recordId }: { recordId: string }) => {
   const dispatch = useAppDispatch();
   const { record } = useRecord(recordId);
   const { setIndex } = useAppSelector((state) => state.editing.status);
-  const { rallies } = record.sets[setIndex];
+  const { entries } = record.sets[setIndex];
   const { players } = record.teams.home;
 
-  // FIXME: 修正編輯狀態 inPlay, isSetPoint 計算邏輯
-  const handleRallyClick = (rallyIndex: number) => {
-    dispatch(
-      editingActions.setEditingRallyStatus({
-        recording: rallies[rallyIndex],
-        status: {
-          isServing:
-            rallyIndex === 0
-              ? record.sets[setIndex].options.serve === "home"
-              : rallies[rallyIndex - 1].win,
-          scores: {
-            home: rallies[rallyIndex].home.score,
-            away: rallies[rallyIndex].away.score,
-          },
-          setIndex,
-          rallyIndex,
-          inPlay: true,
-          isSetPoint: false,
-          recordingMode: "away",
-        },
-      })
-    );
+  const handleEntryClick = (entryIndex: number) => {
+    dispatch(editingActions.setEditingEntryStatus({ record, entryIndex }));
   };
 
   return (
@@ -65,12 +45,12 @@ const RecordOptionsSummary = ({ recordId }: { recordId: string }) => {
       </div>
       <div className="flex flex-col-reverse gap-1">
         <Separator content="比賽開始" />
-        {rallies.map((rally, rallyIndex: number) => (
-          <Rally
-            key={rallyIndex}
-            rally={rally}
+        {entries.map((entry, entryIndex: number) => (
+          <Entry
+            key={entryIndex}
+            entry={entry}
             players={players}
-            onClick={() => handleRallyClick(rallyIndex)}
+            onClick={() => handleEntryClick(entryIndex)}
           />
         ))}
       </div>

--- a/src/components/record/panels/index.tsx
+++ b/src/components/record/panels/index.tsx
@@ -9,10 +9,12 @@ const RecordPanels = ({
   recordId,
   recordState,
   recordActions,
+  className,
 }: {
   recordId: string;
   recordState: ReduxRecordState;
   recordActions: RecordActions | EditingActions;
+  className?: string;
 }) => {
   const { status } = recordState;
 
@@ -24,12 +26,14 @@ const RecordPanels = ({
             recordId={recordId}
             recordState={recordState}
             recordActions={recordActions}
+            className={className}
           />
         ) : (
           <RecordMoves
             recordId={recordId}
             recordState={recordState}
             recordActions={recordActions}
+            className={className}
           />
         )
       ) : (

--- a/src/components/record/panels/moves/oppo.tsx
+++ b/src/components/record/panels/moves/oppo.tsx
@@ -23,7 +23,7 @@ const OppoMoves = ({
   const dispatch = useAppDispatch();
   const { record, mutate } = useRecord(recordId);
   const {
-    status: { setIndex, rallyIndex },
+    status: { setIndex, entryIndex },
     recording,
   } = recordState;
 
@@ -37,17 +37,17 @@ const OppoMoves = ({
     } else {
       try {
         mutate(
-          createRally({ recordId, setIndex, rallyIndex }, recording, record),
+          createRally({ recordId, setIndex, entryIndex }, recording, record),
           {
             revalidate: false,
             optimisticData: createRallyOptimistic(
-              { recordId, setIndex, rallyIndex },
+              { recordId, setIndex, entryIndex },
               recording,
               record
             ),
           }
         );
-        dispatch(recordActions.confirmRecording(record));
+        dispatch(recordActions.confirmRecordingRally(record));
       } catch (error) {
         console.error("[POST /api/records]", error);
       }

--- a/src/components/record/panels/substitutes/index.tsx
+++ b/src/components/record/panels/substitutes/index.tsx
@@ -1,14 +1,13 @@
 "use client";
-import { useState } from "react";
 import { useAppDispatch } from "@/lib/redux/hooks";
 import { useRecord } from "@/hooks/use-data";
 import { FiChevronLeft, FiCheck } from "react-icons/fi";
+import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { createSubstitution } from "@/lib/features/record/actions/create-substitution";
 import { createSubstitutionOptimistic } from "@/lib/features/record/helpers";
 
-import { Side } from "@/entities/record";
 import type { ReduxRecordState } from "@/lib/features/record/types";
 import type { RecordActions } from "@/lib/features/record/record-slice";
 import type { EditingActions } from "@/lib/features/record/editing-slice";
@@ -17,66 +16,55 @@ const Substitutes = ({
   recordId,
   recordState,
   recordActions,
+  className,
 }: {
   recordId: string;
   recordState: ReduxRecordState;
   recordActions: RecordActions | EditingActions;
+  className?: string;
 }) => {
   const dispatch = useAppDispatch();
   const { record, mutate } = useRecord(recordId);
-  const [selectedPlayer, setSelectedPlayer] = useState(null);
   const {
-    status: { setIndex, rallyIndex },
+    status: { setIndex, entryIndex },
     recording,
   } = recordState;
   const players = record.teams.home.players;
   const lineup = record.sets[setIndex].lineups.home;
-  const recordingPlayer =
-    lineup.starting.find((p) => p._id === recording.home.player._id) ||
-    lineup.liberos.find((p) => p._id === recording.home.player._id);
   const substitutes = lineup.substitutes.map((sub) =>
     players.find((player) => player._id === sub._id)
   );
 
   const onSubmit = async () => {
-    const substitution = {
-      team: Side.HOME,
-      rallyIndex: rallyIndex - 1,
-      players: {
-        in: selectedPlayer,
-        out: recordingPlayer._id,
-      },
-    };
     try {
       mutate(
         createSubstitution(
-          { recordId, setIndex, rallyIndex: rallyIndex - 1 },
-          substitution,
+          { recordId, setIndex, entryIndex },
+          recording.substitution,
           record
         ),
         {
           revalidate: false,
           optimisticData: createSubstitutionOptimistic(
-            { recordId, setIndex, rallyIndex: rallyIndex - 1 },
-            substitution,
+            { recordId, setIndex, entryIndex },
+            recording.substitution,
             record
           ),
         }
       );
-      dispatch(recordActions.resetRecording());
-      setSelectedPlayer(null);
+      dispatch(recordActions.confirmRecordingSubstitution());
     } catch (error) {
       console.error("[POST /api/records/sets/substitution]", error);
     }
   };
 
   return (
-    <Card className="flex-1 w-full">
+    <Card className={cn("flex-1 w-full", className)}>
       <CardHeader>
         <Button
           variant="ghost"
           size="icon"
-          onClick={() => dispatch(recordActions.setRecordingMode("home"))}
+          onClick={() => dispatch(recordActions.resetRecordingSubstitution())}
         >
           <FiChevronLeft />
         </Button>
@@ -84,14 +72,21 @@ const Substitutes = ({
       </CardHeader>
       <CardContent className="flex-1">
         {substitutes.map((substitute) => {
-          const toggled = selectedPlayer === substitute._id;
+          const toggled =
+            recording?.substitution?.players?.in === substitute._id;
           return (
             <Button
               key={substitute._id}
               variant={toggled ? "default" : "outline"}
               size="wide"
               className="text-xl"
-              onClick={() => setSelectedPlayer(toggled ? null : substitute._id)}
+              onClick={() =>
+                dispatch(
+                  recordActions.setRecordingSubstitution(
+                    toggled ? null : substitute._id
+                  )
+                )
+              }
             >
               <span className="flex justify-end font-semibold basis-8">
                 {substitute.number}

--- a/src/components/record/preview.tsx
+++ b/src/components/record/preview.tsx
@@ -2,8 +2,9 @@
 import { useRecord } from "@/hooks/use-data";
 import { cn } from "@/lib/utils";
 import { Card } from "@/components/ui/card";
-import Rally from "@/components/record/entry/rally";
+import Entry from "@/components/record/entry";
 
+import { EntryType } from "@/entities/record";
 import type { ReduxRecordState } from "@/lib/features/record/types";
 
 const RecordPreview = ({
@@ -21,21 +22,28 @@ const RecordPreview = ({
   const { players } = record.teams.home;
   const {
     recording,
-    status: { inPlay, setIndex, rallyIndex },
+    status: { inPlay, setIndex, entryIndex },
   } = recordState;
 
   if (!inPlay) return null;
 
-  const lastRally = record.sets[setIndex].rallies[rallyIndex - 1];
+  const lastRally = record.sets[setIndex].entries[entryIndex - 1];
   const isEditing = recording.home.player._id || recording.home.type;
-  const rally = isEditing || rallyIndex === 0 ? recording : lastRally;
+  const recordingEntry = recording.substitution
+    ? { type: EntryType.SUBSTITUTION, data: recording.substitution }
+    : recording.timeout
+    ? { type: EntryType.TIMEOUT, data: recording.timeout }
+    : recording.challenge
+    ? { type: EntryType.CHALLENGE, data: recording.challenge }
+    : { type: EntryType.RALLY, data: recording };
+  const entry = isEditing || entryIndex === 0 ? recordingEntry : lastRally;
 
   return (
     <Card className={cn("grid w-full p-2", className)}>
-      <Rally
-        rally={rally}
+      <Entry
+        entry={entry}
         players={players}
-        onClick={handleOptionOpen ? () => handleOptionOpen("rallies") : null}
+        onClick={handleOptionOpen ? () => handleOptionOpen("summary") : null}
         className={isEditing ? "animate-pulse duration-1000" : ""}
       />
     </Card>

--- a/src/entities/record.ts
+++ b/src/entities/record.ts
@@ -145,7 +145,7 @@ export type RallyDetail = {
   score: number;
   type: MoveType;
   num: number;
-  player: {
+  player?: {
     _id: string;
     zone: number;
   };
@@ -164,7 +164,6 @@ export enum Side {
 
 export type Substitution = {
   team: Side;
-  rallyIndex: number;
   players: {
     in: string;
     out: string;
@@ -173,14 +172,24 @@ export type Substitution = {
 
 export type Timeout = {
   team: Side;
-  rallyIndex: number;
 };
 
 export type Challenge = {
   team: Side;
-  rallyIndex: number;
   type: string;
   success: boolean;
+};
+
+export enum EntryType {
+  RALLY,
+  SUBSTITUTION,
+  TIMEOUT,
+  CHALLENGE,
+}
+
+export type Entry = {
+  type: EntryType;
+  data: Rally | Substitution | Timeout | Challenge;
 };
 
 export type Set = {
@@ -196,10 +205,7 @@ export type Set = {
       end: string;
     };
   };
-  rallies: Rally[];
-  substitutions: Substitution[];
-  timeouts: Timeout[];
-  challenges: Challenge[];
+  entries: Entry[];
 };
 
 export type Record = {

--- a/src/infrastructure/mongoose/schemas/record.ts
+++ b/src/infrastructure/mongoose/schemas/record.ts
@@ -5,6 +5,7 @@ import {
   MatchPhase,
   MoveType,
   Side,
+  EntryType,
 } from "@/entities/record";
 import { lineupSchema } from "@/infrastructure/mongoose/schemas/team";
 
@@ -136,7 +137,6 @@ const rallySchema = new Schema({
 
 const substitutionSchema = new Schema({
   team: { type: Number, enum: Side },
-  rallyIndex: { type: Number },
   players: {
     in: { type: Schema.Types.ObjectId, ref: "Member" },
     out: { type: Schema.Types.ObjectId, ref: "Member" },
@@ -145,14 +145,17 @@ const substitutionSchema = new Schema({
 
 const timeoutSchema = new Schema({
   team: { type: Number, enum: Side },
-  rallyIndex: { type: Number },
 });
 
 const challengeSchema = new Schema({
   team: { type: Number, enum: Side },
-  rallyIndex: { type: Number },
   type: { type: String },
   success: { type: Boolean },
+});
+
+const entrySchema = new Schema({
+  type: { type: Number, enum: EntryType },
+  data: { type: Schema.Types.Mixed },
 });
 
 const setSchema = new Schema({
@@ -168,10 +171,7 @@ const setSchema = new Schema({
       end: { type: String },
     },
   },
-  rallies: [{ type: rallySchema }],
-  substitutions: [{ type: substitutionSchema }],
-  timeouts: [{ type: timeoutSchema }],
-  challenges: [{ type: challengeSchema }],
+  entries: [{ type: entrySchema }],
 });
 
 const recordSchema = new Schema(

--- a/src/lib/features/record/actions/create-rally.ts
+++ b/src/lib/features/record/actions/create-rally.ts
@@ -1,14 +1,14 @@
 import type { Record, Rally } from "@/entities/record";
 
 export const createRally = async (
-  params: { recordId: string; setIndex: number; rallyIndex: number },
+  params: { recordId: string; setIndex: number; entryIndex: number },
   recording: Rally,
   record: Record
 ) => {
-  const { recordId, setIndex, rallyIndex } = params;
+  const { recordId, setIndex, entryIndex } = params;
   try {
     const res = await fetch(
-      `/api/records/${recordId}/sets/rallies?si=${setIndex}&ri=${rallyIndex}`,
+      `/api/records/${recordId}/sets/rallies?si=${setIndex}&ei=${entryIndex}`,
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -16,10 +16,10 @@ export const createRally = async (
       }
     );
     if (!res.ok) throw new Error("Network response was not ok");
-    const rallies = await res.json();
-    record.sets[setIndex].rallies = rallies;
+    const entries = await res.json();
+    record.sets[setIndex].entries = entries;
     return record;
   } catch (error) {
-    console.error("[POST /api/records]", error);
+    console.error("[CREAT Rally]", error);
   }
 };

--- a/src/lib/features/record/actions/create-substitution.ts
+++ b/src/lib/features/record/actions/create-substitution.ts
@@ -1,14 +1,14 @@
 import type { Record, Substitution } from "@/entities/record";
 
 export const createSubstitution = async (
-  params: { recordId: string; setIndex: number; rallyIndex: number },
+  params: { recordId: string; setIndex: number; entryIndex: number },
   substitution: Substitution,
   record: Record
 ) => {
-  const { recordId, setIndex, rallyIndex } = params;
+  const { recordId, setIndex, entryIndex } = params;
   try {
     const res = await fetch(
-      `/api/records/${recordId}/sets/substitutions?si=${setIndex}&ri=${rallyIndex}`,
+      `/api/records/${recordId}/sets/substitutions?si=${setIndex}&ei=${entryIndex}`,
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -16,10 +16,10 @@ export const createSubstitution = async (
       }
     );
     if (!res.ok) throw new Error("Network response was not ok");
-    const substitutions = await res.json();
-    record.sets[setIndex].substitutions = substitutions;
+    const entries = await res.json();
+    record.sets[setIndex].entries = entries;
     return record;
   } catch (error) {
-    console.error("[POST /api/records]", error);
+    console.error("[CREATE Substitution]", error);
   }
 };

--- a/src/lib/features/record/helpers/create-rally.helper.ts
+++ b/src/lib/features/record/helpers/create-rally.helper.ts
@@ -1,14 +1,16 @@
-import type { Record, Rally } from "@/entities/record";
+import { getPreviousRally } from "@/lib/features/record/helpers";
+import { type Record, type Rally, EntryType } from "@/entities/record";
 
 export const createRallyOptimistic = (
-  params: { recordId: string; setIndex: number; rallyIndex: number },
+  params: { recordId: string; setIndex: number; entryIndex: number },
   recording: Rally,
   record: Record
 ) => {
-  const { setIndex, rallyIndex } = params;
+  const { setIndex, entryIndex } = params;
   const { win, home, away } = recording;
-  const isServing = rallyIndex
-    ? record.sets[setIndex].rallies[rallyIndex - 1]?.win
+  const previousRally = getPreviousRally(record, setIndex, entryIndex);
+  const isServing = previousRally
+    ? previousRally.win
     : record.sets[setIndex].options.serve === "home";
   if (win && !isServing) record.teams.home.stats[setIndex].rotation += 1;
 
@@ -37,7 +39,10 @@ export const createRallyOptimistic = (
 
   record.teams.home = homeTeam;
   record.teams.away = awayTeam;
-  record.sets[setIndex].rallies[rallyIndex] = recording;
+  record.sets[setIndex].entries[entryIndex] = {
+    type: EntryType.RALLY,
+    data: recording,
+  };
 
   return record;
 };

--- a/src/lib/features/record/helpers/create-substitution.helper.ts
+++ b/src/lib/features/record/helpers/create-substitution.helper.ts
@@ -1,11 +1,16 @@
-import { type Record, Side, type Substitution } from "@/entities/record";
+import {
+  type Record,
+  Side,
+  type Substitution,
+  EntryType,
+} from "@/entities/record";
 
 export const createSubstitutionOptimistic = (
-  params: { recordId: string; setIndex: number; rallyIndex: number },
+  params: { recordId: string; setIndex: number; entryIndex: number },
   substitution: Substitution,
   record: Record
 ) => {
-  const { setIndex } = params;
+  const { setIndex, entryIndex } = params;
   const {
     team,
     players: { in: inPlayer, out: outPlayer },
@@ -32,7 +37,10 @@ export const createSubstitutionOptimistic = (
   lineup.starting[startingIndex] = startingPlayer;
   lineup.substitutes[subIndex] = subPlayer;
   record.sets[setIndex].lineups[side] = lineup;
-  record.sets[setIndex].substitutions.push(substitution);
+  record.sets[setIndex].entries[entryIndex] = {
+    type: EntryType.SUBSTITUTION,
+    data: substitution,
+  };
   record.teams[side].stats[setIndex].substitution += 1;
 
   return record;

--- a/src/lib/features/record/helpers/get-previous-rally.helper.ts
+++ b/src/lib/features/record/helpers/get-previous-rally.helper.ts
@@ -1,0 +1,19 @@
+import { type Record, type Rally, EntryType } from "@/entities/record";
+
+export const getPreviousRally = (
+  record: Record,
+  setIndex: number,
+  entryIndex: number
+): Rally => {
+  const set = record.sets[setIndex];
+
+  if (entryIndex === 0) return null;
+
+  for (let i = entryIndex - 1; i >= 0; i--) {
+    if (set.entries[i].type === EntryType.RALLY) {
+      return set.entries[i].data as Rally;
+    }
+  }
+
+  return null;
+};

--- a/src/lib/features/record/helpers/index.ts
+++ b/src/lib/features/record/helpers/index.ts
@@ -1,9 +1,11 @@
 import { matchPhaseHelper } from "@/lib/features/record/helpers/match-phase.helper";
 import { createRallyOptimistic } from "@/lib/features/record/helpers/create-rally.helper";
 import { createSubstitutionOptimistic } from "@/lib/features/record/helpers/create-substitution.helper";
+import { getPreviousRally } from "@/lib/features/record/helpers/get-previous-rally.helper";
 
 export {
   matchPhaseHelper,
   createRallyOptimistic,
   createSubstitutionOptimistic,
+  getPreviousRally,
 };

--- a/src/lib/features/record/helpers/match-phase.helper.ts
+++ b/src/lib/features/record/helpers/match-phase.helper.ts
@@ -12,10 +12,10 @@ export const matchPhaseHelper = (
   const isDecidingSet = setIndex === record.info.scoring.setCount - 1;
   const point = isDecidingSet ? record.info.scoring.decidingSetPoints : 25;
 
-  // In the first set, though there is no rally recorded yet,
-  // the game is `in progress (inPlay)` if `rallies` of the first set has been created
+  // In the first set, though there is no entries recorded yet,
+  // the game is `in progress (inPlay)` if `entries` of the first set has been created
   if (!rally) {
-    if (record?.sets[0]?.rallies) return { inPlay: true, isSetPoint: false };
+    if (record?.sets[0]?.entries) return { inPlay: true, isSetPoint: false };
     return { inPlay: false, isSetPoint: false };
   }
 

--- a/src/lib/features/record/types.ts
+++ b/src/lib/features/record/types.ts
@@ -1,5 +1,10 @@
 import { z } from "zod";
-import type { Rally } from "@/entities/record";
+import type {
+  Rally,
+  Substitution,
+  Timeout,
+  Challenge,
+} from "@/entities/record";
 
 // For Forms and Tables
 export const RecordInfoFormSchema = z.object({
@@ -73,7 +78,7 @@ export type ReduxStatus = {
     away: number;
   };
   setIndex: number;
-  rallyIndex: number;
+  entryIndex: number;
   inPlay: boolean;
   isSetPoint: boolean;
   recordingMode: "home" | "away" | "substitutes";
@@ -84,5 +89,9 @@ export type ReduxRecordState = {
   win: boolean | null;
   status: ReduxStatus;
   isEditing?: boolean;
-  recording: Rally;
+  recording: Rally & {
+    substitution?: Substitution;
+    timeout?: Timeout;
+    challenge?: Challenge;
+  };
 };


### PR DESCRIPTION
changes:
- use `set.entries` to accommodate `rally`, `substitution`, `timeout`, and `challenge`
- change return value of `createRally` and `createSubstitution` to `Entry[]`
- adjust `Entry` ui components for `Preview` and `Summary`