### PR TITLE
feat(editing-mode): reflect rotation and substitution status in Court during editing

### DIFF
--- a/src/applications/use-cases/record/create-substitution.use-case.ts
+++ b/src/applications/use-cases/record/create-substitution.use-case.ts
@@ -4,12 +4,14 @@ import { IRecordRepository } from "@/applications/repositories/record.repository
 import { AuthenticationService } from "@/infrastructure/service/auth/authentication.service";
 import { AuthorizationService } from "@/infrastructure/service/auth/authorization.service";
 import {
+  type Record,
+  type Entry,
   type Substitution,
   Side,
   EntryType,
-  type Entry,
+  PlayerStatsClass,
 } from "@/entities/record";
-import { Role } from "@/entities/team";
+import { Role, type Lineup } from "@/entities/team";
 
 export interface ICreateSubstitutionInput {
   params: { recordId: string; setIndex: number; entryIndex: number };
@@ -19,80 +21,100 @@ export interface ICreateSubstitutionInput {
 export type ICreateSubstitutionOutput = Entry[];
 
 export class CreateSubstitutionUseCase {
-  private userRepository: IUserRepository;
-  private teamRepository: ITeamRepository;
-  private recordRepository: IRecordRepository;
-
   constructor(
-    userRepository: IUserRepository,
-    teamRepository: ITeamRepository,
-    recordRepository: IRecordRepository
-  ) {
-    this.userRepository = userRepository;
-    this.teamRepository = teamRepository;
-    this.recordRepository = recordRepository;
-  }
+    private userRepository: IUserRepository,
+    private teamRepository: ITeamRepository,
+    private recordRepository: IRecordRepository
+  ) {}
 
   async execute(
     input: ICreateSubstitutionInput
-  ): Promise<ICreateSubstitutionOutput | undefined> {
+  ): Promise<ICreateSubstitutionOutput> {
     const { params, data: substitution } = input;
-    const authenticationService = new AuthenticationService(
+    const user = await new AuthenticationService(
       this.userRepository
-    );
-    const user = await authenticationService.verifySession();
+    ).verifySession();
 
     const record = await this.recordRepository.findOne({
       _id: params.recordId,
     });
     if (!record) throw new Error("Record not found");
 
-    const authorizationService = new AuthorizationService(this.teamRepository);
-    await authorizationService.verifyTeamRole(
+    await new AuthorizationService(this.teamRepository).verifyTeamRole(
       record.team_id.toString(),
       user._id.toString(),
       Role.MEMBER
     );
 
-    const { setIndex, entryIndex } = params;
-    const {
-      team,
-      players: { in: inPlayer, out: outPlayer },
-    } = substitution;
+    const side = substitution.team === Side.HOME ? "home" : "away";
+    const lineup = record.sets[params.setIndex].lineups[side];
 
-    const side = team === Side.HOME ? "home" : "away";
+    this.updateLineup(lineup, substitution, params.entryIndex);
+    this.updateRecordStats(record, side, input);
+
+    await this.recordRepository.update({ _id: params.recordId }, record);
+    return record.sets[params.setIndex].entries;
+  }
+
+  private updateLineup(
+    lineup: Lineup,
+    substitution: Substitution,
+    entryIndex: number
+  ) {
+    const startingIndex = lineup.starting.findIndex(
+      (p) => p._id.toString() === substitution.players.out
+    );
+    const subIndex = lineup.substitutes.findIndex(
+      (p) => p._id.toString() === substitution.players.in
+    );
+
+    lineup.starting[startingIndex] = {
+      _id: substitution.players.in,
+      position: lineup.starting[startingIndex].position,
+      sub: {
+        _id: substitution.players.out,
+        entryIndex:
+          lineup.starting[startingIndex].sub?.entryIndex?.in !== undefined
+            ? {
+                ...lineup.starting[startingIndex].sub.entryIndex,
+                out: entryIndex,
+              }
+            : { in: entryIndex, out: null },
+      },
+    };
+
+    lineup.substitutes[subIndex] = {
+      ...lineup.substitutes[subIndex],
+      _id: substitution.players.out,
+      sub: { _id: substitution.players.in },
+    };
+  }
+
+  private updateRecordStats(
+    record: Record,
+    side: string,
+    input: ICreateSubstitutionInput
+  ) {
+    const {
+      params: { setIndex, entryIndex },
+      data: substitution,
+    } = input;
     const lineup = record.sets[setIndex].lineups[side];
 
-    const startingIndex = lineup.starting.findIndex(
-      (p) => p._id.toString() === outPlayer
+    const startingPlayer = lineup.starting.find(
+      (p) => p._id.toString() === substitution.players.in
     );
-    const startingPlayer = lineup.starting[startingIndex];
-    const subIndex = lineup.substitutes.findIndex(
-      (p) => p._id.toString() === inPlayer
-    );
-    const subPlayer = lineup.substitutes[subIndex];
-
-    startingPlayer._id = inPlayer;
-    subPlayer._id = outPlayer;
-    subPlayer.sub = { _id: inPlayer };
-
-    if (!!startingPlayer.sub?._id) {
-      startingPlayer.sub._id = null;
-    } else {
-      startingPlayer.sub = { _id: outPlayer };
+    if (!!startingPlayer.sub?.entryIndex?.in !== undefined) {
+      const player = record.teams[side].players.find(
+        (p) => p._id.toString() === substitution.players.in
+      );
+      if (player) player.stats[setIndex] = new PlayerStatsClass();
     }
 
-    lineup.starting[startingIndex] = startingPlayer;
-    lineup.substitutes[subIndex] = subPlayer;
-    record.sets[setIndex].lineups[side] = lineup;
+    record.teams[side].stats[setIndex].substitution++;
     record.sets[setIndex].entries[entryIndex] = {
       type: EntryType.SUBSTITUTION,
       data: substitution,
     };
-    record.teams[side].stats[setIndex].substitution += 1;
-
-    await this.recordRepository.update({ _id: params.recordId }, record);
-
-    return record.sets[setIndex].entries;
   }
 }

--- a/src/components/custom/court/index.tsx
+++ b/src/components/custom/court/index.tsx
@@ -134,20 +134,19 @@ export const SubIndicator = ({ number }: { number: number }) => {
 
 export const PlayerCard = ({
   player,
+  toggled,
   list,
   zone,
   onClick,
-  editingMember,
   children,
 }: {
   player: Player & { position: string };
+  toggled: boolean;
   list: string;
   zone: number;
   onClick: () => void;
-  editingMember: { _id: string; list: string; zone: number };
   children?: React.ReactNode;
 }) => {
-  const toggled = editingMember.list === list && editingMember.zone === zone;
   return (
     <Card
       style={list === "starting" ? { gridArea: `z${zone}` } : {}}

--- a/src/components/record/court.tsx
+++ b/src/components/record/court.tsx
@@ -10,12 +10,18 @@ import {
   AdjustButton,
   PlaceholderCard,
 } from "@/components/custom/court";
+import type { ReduxRecordState } from "@/lib/features/record/types";
 
-const RecordCourt = ({ recordId }: { recordId: string }) => {
+const RecordCourt = ({
+  recordId,
+  mode,
+}: {
+  recordId: string;
+  mode: ReduxRecordState["mode"];
+}) => {
   const dispatch = useAppDispatch();
-  const recordState = useAppSelector((state) => state.record);
-  const { status, recording } = recordState[recordState.mode];
-  const { starting, liberos } = useLineup(recordId, recordState);
+  const { status, recording } = useAppSelector((state) => state.record[mode]);
+  const { starting, liberos } = useLineup(recordId, status);
 
   if (status.inProgress === false) {
     return (
@@ -42,22 +48,14 @@ const RecordCourt = ({ recordId }: { recordId: string }) => {
           <PlayerCard
             key={index}
             player={player}
+            toggled={recording.home.player._id === player._id}
             list="liberos"
             zone={-(index + 1)}
-            onClick={() =>
-              dispatch(
-                recordActions.setRecordingPlayer({
-                  _id: player._id,
-                  zone: -(index + 1),
-                })
-              )
-            }
-            editingMember={{
-              ...recording.home.player,
-              list: recording.home.player.zone > 0 ? "starting" : "liberos",
-            }}
+            onClick={() => {}}
           >
-            {player.sub?._id && <SubIndicator number={player.sub.number} />}
+            {player.sub?._id && !player.sub?.entryIndex?.out && (
+              <SubIndicator number={player.sub.number} />
+            )}
           </PlayerCard>
         ))}
       </Outside>
@@ -66,6 +64,7 @@ const RecordCourt = ({ recordId }: { recordId: string }) => {
           <PlayerCard
             key={index}
             player={player}
+            toggled={recording.home.player._id === player._id}
             list="starting"
             zone={index + 1}
             onClick={() =>
@@ -76,12 +75,10 @@ const RecordCourt = ({ recordId }: { recordId: string }) => {
                 })
               )
             }
-            editingMember={{
-              ...recording.home.player,
-              list: recording.home.player.zone > 0 ? "starting" : "liberos",
-            }}
           >
-            {player.sub?._id && <SubIndicator number={player.sub.number} />}
+            {player.sub?._id && !player.sub?.entryIndex?.out && (
+              <SubIndicator number={player.sub.number} />
+            )}
           </PlayerCard>
         ))}
       </Inside>

--- a/src/components/record/index.tsx
+++ b/src/components/record/index.tsx
@@ -47,7 +47,7 @@ const Record = ({ recordId }: { recordId: string }) => {
   return (
     <>
       <Header recordId={record._id} handleOptionOpen={handleOptionOpen} />
-      <RecordCourt recordId={record._id} />
+      <RecordCourt recordId={record._id} mode="general" />
       <RecordPreview
         recordId={record._id}
         handleOptionOpen={handleOptionOpen}

--- a/src/components/record/options/edit/index.tsx
+++ b/src/components/record/options/edit/index.tsx
@@ -24,7 +24,7 @@ const EntriesEdit = ({ recordId }: { recordId: string }) => {
         </Button>
         <DialogTitle>編輯逐球紀錄</DialogTitle>
       </DialogHeader>
-      <RecordCourt recordId={recordId} />
+      <RecordCourt recordId={recordId} mode="editing" />
       <RecordPreview recordId={recordId} className="px-0 py-1 shadow-none" />
       <RecordPanels recordId={recordId} className="p-0 shadow-none" />
     </>

--- a/src/components/team/lineup/court.tsx
+++ b/src/components/team/lineup/court.tsx
@@ -37,6 +37,10 @@ const LineupCourt = ({ members }) => {
               <PlayerCard
                 key={index}
                 player={player}
+                toggled={
+                  status.editingMember.list === "liberos" &&
+                  status.editingMember.zone === index + 1
+                }
                 list="liberos"
                 zone={index + 1}
                 onClick={() =>
@@ -48,13 +52,17 @@ const LineupCourt = ({ members }) => {
                     })
                   )
                 }
-                editingMember={status.editingMember}
               />
             );
           })}
         {lineups[status.lineupIndex]?.liberos.length < 2 && (
           <PlayerCard
             player={null}
+            toggled={
+              status.editingMember.list === "liberos" &&
+              status.editingMember.zone ===
+                lineups[status.lineupIndex]?.liberos.length + 1
+            }
             list="liberos"
             zone={lineups[status.lineupIndex]?.liberos.length + 1}
             onClick={() =>
@@ -66,7 +74,6 @@ const LineupCourt = ({ members }) => {
                 })
               )
             }
-            editingMember={status.editingMember}
           />
         )}
       </Outside>
@@ -84,6 +91,10 @@ const LineupCourt = ({ members }) => {
               <PlayerCard
                 key={index}
                 player={player}
+                toggled={
+                  status.editingMember.list === "starting" &&
+                  status.editingMember.zone === index + 1
+                }
                 list="starting"
                 zone={index + 1}
                 onClick={() =>
@@ -95,7 +106,6 @@ const LineupCourt = ({ members }) => {
                     })
                   )
                 }
-                editingMember={status.editingMember}
               />
             );
           })}

--- a/src/entities/team.ts
+++ b/src/entities/team.ts
@@ -9,6 +9,12 @@ export enum Position {
   L = "L",
 }
 
+export type LineupPlayer = {
+  _id: string;
+  position: Position;
+  sub?: { _id: string; entryIndex: { in?: number; out?: number } };
+};
+
 export type Lineup = {
   options: {
     liberoSwitchMode: 0 | 1 | 2;
@@ -18,16 +24,8 @@ export type Lineup = {
       | Position.MB
       | Position.OP;
   };
-  starting: {
-    _id: string;
-    position: Position;
-    sub?: { _id: string };
-  }[];
-  liberos: {
-    _id: string;
-    position: Position;
-    sub?: { _id: string };
-  }[];
+  starting: LineupPlayer[];
+  liberos: LineupPlayer[];
   substitutes: {
     _id: string;
     sub?: { _id: string };

--- a/src/infrastructure/mongoose/schemas/team.ts
+++ b/src/infrastructure/mongoose/schemas/team.ts
@@ -14,14 +14,20 @@ export const lineupSchema = new Schema({
     {
       _id: { type: Schema.Types.ObjectId, ref: "Member" },
       position: { type: String, enum: Position },
-      sub: { _id: { type: Schema.Types.ObjectId, ref: "Member" } },
+      sub: {
+        _id: { type: Schema.Types.ObjectId, ref: "Member" },
+        entryIndex: { in: { type: Number }, out: { type: Number } },
+      },
     },
   ],
   liberos: [
     {
       _id: { type: Schema.Types.ObjectId, ref: "Member" },
       position: { type: String, enum: Position },
-      sub: { _id: { type: Schema.Types.ObjectId, ref: "Member" } },
+      sub: {
+        _id: { type: Schema.Types.ObjectId, ref: "Member" },
+        entryIndex: { in: { type: Number }, out: { type: Number } },
+      },
     },
   ],
   substitutes: [

--- a/src/lib/features/record/hooks/use-lineup.ts
+++ b/src/lib/features/record/hooks/use-lineup.ts
@@ -1,18 +1,14 @@
 import { useRecord } from "@/hooks/use-data";
-import type { ReduxRecordState } from "@/lib/features/record/types";
+import { type LineupPlayer } from "@/entities/team";
+import { type Record, EntryType, Rally } from "@/entities/record";
+import type { ReduxStatus } from "@/lib/features/record/types";
 
-export const useLineup = (recordId: string, recordState: ReduxRecordState) => {
-  const { setIndex, isServing, inProgress } =
-    recordState[recordState.mode].status;
-  const { record } = useRecord(recordId);
-
-  if (!inProgress) return { starting: [], liberos: [] };
-
-  const { players, stats } = record.teams.home;
-  const { starting, liberos, options } = structuredClone(
+const getGeneralModeLineup = (record: Record, status: ReduxStatus) => {
+  const { setIndex } = status;
+  const { starting, liberos } = structuredClone(
     record.sets[setIndex].lineups.home
   );
-
+  const { players, stats } = record.teams.home;
   const lineup = {
     liberos: liberos.map((libero) => {
       const player = players.find((p) => p._id === libero._id);
@@ -20,7 +16,11 @@ export const useLineup = (recordId: string, recordState: ReduxRecordState) => {
       return {
         ...player,
         position: libero.position,
-        sub: { _id: substitute?._id, number: substitute?.number },
+        sub: {
+          _id: substitute?._id,
+          number: substitute?.number,
+          entryIndex: libero?.sub?.entryIndex,
+        },
       };
     }),
     starting: starting.map((starter) => {
@@ -29,7 +29,11 @@ export const useLineup = (recordId: string, recordState: ReduxRecordState) => {
       return {
         ...player,
         position: starter.position,
-        sub: { _id: substitute?._id, number: substitute?.number },
+        sub: {
+          _id: substitute?._id,
+          number: substitute?.number,
+          entryIndex: starter?.sub?.entryIndex,
+        },
       };
     }),
   };
@@ -39,9 +43,97 @@ export const useLineup = (recordId: string, recordState: ReduxRecordState) => {
     const rotatedPlayers = lineup.starting.splice(0, rotation);
     lineup.starting.push(...rotatedPlayers);
   }
+
+  return lineup;
+};
+
+const getEditingModeLineup = (record: Record, status: ReduxStatus) => {
+  const { setIndex, entryIndex } = status;
+  const { players } = record.teams.home;
+  const set = record.sets[setIndex];
+
+  // Calculate serving and rotation
+  const { rotation } = set.entries.slice(0, entryIndex).reduce(
+    (acc, entry) => {
+      if (
+        entry.type === EntryType.RALLY &&
+        (entry.data as Rally)?.win !== acc.isServing
+      ) {
+        return {
+          isServing: !acc.isServing,
+          rotation: (acc.rotation + 1) % 6,
+        };
+      }
+      return acc;
+    },
+    { isServing: set.options.serve === "home", rotation: 0 }
+  );
+
+  const { starting, liberos } = structuredClone(set.lineups.home);
+
+  const mapPlayer = (player: LineupPlayer) => {
+    // Whether this player has been substituted in the game
+    const haveSub = player?.sub?.entryIndex?.in < entryIndex;
+    // Current game state shows this player is a substitute
+    const isSub =
+      player?.sub?.entryIndex?.in !== undefined &&
+      !player?.sub?.entryIndex?.out;
+    // At the editing point, this player was a substitute
+    const wasSub =
+      player?.sub?.entryIndex?.in < entryIndex &&
+      (!player?.sub?.entryIndex?.out ||
+        player?.sub?.entryIndex?.out >= entryIndex);
+    // When a player (LineupPlayer) is substituted, their _id and sub._id are swapped
+    // So when isSub and wasSub are the same, it means no need to swap _id and sub._id
+    const toSwap = isSub === wasSub;
+
+    const mainPlayer = players.find(
+      (p) => p._id === (toSwap ? player._id : player?.sub?._id)
+    );
+    const subPlayer = players.find(
+      (p) => p._id === (haveSub && (toSwap ? player?.sub?._id : player._id))
+    );
+
+    return {
+      ...mainPlayer,
+      position: player.position,
+      sub: {
+        _id: subPlayer?._id,
+        number: subPlayer?.number,
+        entryIndex: player?.sub?.entryIndex,
+      },
+    };
+  };
+
+  const lineup = {
+    liberos: liberos.map(mapPlayer),
+    starting: starting.map(mapPlayer),
+  };
+
+  if (rotation) {
+    const rotatedPlayers = lineup.starting.splice(0, rotation);
+    lineup.starting.push(...rotatedPlayers);
+  }
+
+  return lineup;
+};
+
+export const useLineup = (recordId: string, status: ReduxStatus) => {
+  const { setIndex, entryIndex, isServing, inProgress } = status;
+  const { record } = useRecord(recordId);
+
+  if (!inProgress) return { starting: [], liberos: [] };
+
+  const { entries, lineups } = record.sets[setIndex];
+
+  const lineup =
+    entryIndex === entries.length
+      ? getGeneralModeLineup(record, status)
+      : getEditingModeLineup(record, status);
+
   const switchTargetIndex = lineup.starting.findIndex(
     (player, index) =>
-      player.position === options.liberoSwitchPosition &&
+      player.position === lineups.home.options.liberoSwitchPosition &&
       ((index === 0 && !isServing) || index >= 4)
   );
   if (switchTargetIndex !== -1) {

--- a/src/lib/features/record/record-slice.ts
+++ b/src/lib/features/record/record-slice.ts
@@ -290,18 +290,20 @@ const setEditingEntryStatus: CaseReducer<
 
   state.mode = "editing";
   state.editing.recording = {
-    win:
-      entry.type === EntryType.RALLY
-        ? (entry.data as Rally).win
-        : state.editing.recording.win,
+    win: entry.type === EntryType.RALLY ? (entry.data as Rally).win : null,
     home:
       entry.type === EntryType.RALLY
         ? (entry.data as Rally).home
-        : state.editing.recording.home,
+        : entry.type === EntryType.SUBSTITUTION
+        ? {
+            ...rallyDetailState,
+            player: { _id: (entry.data as Substitution).players.out, zone: 0 },
+          }
+        : rallyDetailState,
     away:
       entry.type === EntryType.RALLY
         ? (entry.data as Rally).away
-        : state.editing.recording.away,
+        : rallyDetailState,
     ...(entry.type === EntryType.SUBSTITUTION
       ? { substitution: entry.data as Substitution }
       : entry.type === EntryType.TIMEOUT


### PR DESCRIPTION
changes:

- Add `entryIndex` to `LineupPlayer` for substitution timing
- Update `createSubstitution` to handle substitution timing and add corresponding `PlayerStats` for substituted players
- Refactor `useLineup` to ensure Court reflects rotation and substitution status in Editing mode