### PR TITLE
Fix semantic-release version update in package files

### DIFF
--- a/release.config.ts
+++ b/release.config.ts
@@ -11,7 +11,7 @@ const config: Partial<GlobalConfig> = {
     [
       "@semantic-release/git",
       {
-        assets: ["docs/CHANGELOG.md"],
+        assets: ["docs/CHANGELOG.md", "package.json", "package-lock.json"],
         message:
           "release: ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}",
       },


### PR DESCRIPTION
## Problem
semantic-release currently doesn't update version numbers in `package.json` and `package-lock.json` when creating new releases, keeping the project at version 0.5.1 despite new releases.

## Solution
Add `package.json` and `package-lock.json` to the assets list in the @semantic-release/git plugin configuration.

## Expected Results
After this fix, semantic-release will:

- Update version in `package.json`
- Update `package-lock.json]` accordingly
- Commit these changes with the CHANGELOG updates