### PR TITLE
fix(pwa): add apple-mobile-web-app-capable meta tag to enable iOS splash screen

### DIFF
--- a/release.config.ts
+++ b/release.config.ts
@@ -11,7 +11,7 @@ const config: Partial<GlobalConfig> = {
     [
       "@semantic-release/git",
       {
-        assets: ["docs/CHANGELOG.md"],
+        assets: ["docs/CHANGELOG.md", "package.json", "package-lock.json"],
         message:
           "release: ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}",
       },


### PR DESCRIPTION
- Fix startup images not displaying on iOS devices