### PR TITLE
feat(record): add `Interval` component in `Record` layout when a set ends

### DIFF
--- a/src/app/record/layout.tsx
+++ b/src/app/record/layout.tsx
@@ -1,11 +1,9 @@
-const RocordLayout = ({ children }: { children: React.ReactNode }) => {
+const RecordLayout = ({ children }: { children: React.ReactNode }) => {
   return (
     <main className="flex size-full flex-col items-center justify-start pt-[calc(env(safe-area-inset-top)+5.5rem)]">
-      <div className="flex size-full max-w-[640px] flex-col items-center justify-start gap-1 overflow-hidden">
-        {children}
-      </div>
+      {children}
     </main>
   );
 };
 
-export default RocordLayout;
+export default RecordLayout;

--- a/src/components/match/stats/index.tsx
+++ b/src/components/match/stats/index.tsx
@@ -44,6 +44,33 @@ export const Stats = ({ recordId }: { recordId: string }) => {
   );
 };
 
+export const StatsForOneSet = ({
+  recordId,
+  setIndex,
+}: {
+  recordId: string;
+  setIndex: number;
+}) => {
+  const { record } = useRecord(recordId);
+
+  return (
+    <Card className="w-full">
+      <Tabs defaultValue="team-stats" className="relative w-full">
+        <TabsList className="grid w-full grid-cols-2">
+          <TabsTrigger value="team-stats">隊伍數據</TabsTrigger>
+          <TabsTrigger value="box-score" disabled>
+            個人數據
+          </TabsTrigger>
+        </TabsList>
+        <TabsContent value="team-stats">
+          <TeamsStats teams={record.teams} setIndex={setIndex} />
+        </TabsContent>
+        <TabsContent value="box-score"></TabsContent>
+      </Tabs>
+    </Card>
+  );
+};
+
 const SetSwitch = ({
   sets,
   setIndex,

--- a/src/components/record/header/index.tsx
+++ b/src/components/record/header/index.tsx
@@ -14,7 +14,7 @@ export const RecordHeader = ({
   const router = useRouter();
 
   return (
-    <header className="fixed top-0 z-10 flex w-full max-w-[640px] items-center justify-between h-21">
+    <header className="fixed top-0 z-10 flex h-21 w-full max-w-[640px] items-center justify-between">
       <div className="flex w-full items-center justify-between gap-2 rounded-b-lg bg-card px-2 pt-[env(safe-area-inset-top)] shadow-sm">
         <Button
           variant="ghost"

--- a/src/components/record/header/index.tsx
+++ b/src/components/record/header/index.tsx
@@ -26,16 +26,20 @@ export const RecordHeader = ({
         </Button>
         <Scores
           recordId={recordId}
-          onClick={() => handleOptionOpen("overview")}
+          onClick={handleOptionOpen && (() => handleOptionOpen("overview"))}
         />
-        <Button
-          variant="ghost"
-          className="[&>svg]:size-8"
-          onClick={() => handleOptionOpen("settings")}
-        >
-          <RiSettings4Line />
-          <span className="sr-only">Options</span>
-        </Button>
+        {handleOptionOpen ? (
+          <Button
+            variant="ghost"
+            className="[&>svg]:size-8"
+            onClick={() => handleOptionOpen("settings")}
+          >
+            <RiSettings4Line />
+            <span className="sr-only">Options</span>
+          </Button>
+        ) : (
+          <div className="size-12"></div>
+        )}
       </div>
     </header>
   );

--- a/src/components/record/index.tsx
+++ b/src/components/record/index.tsx
@@ -97,7 +97,7 @@ const Interval = ({
 }) => {
   return (
     <>
-      <RecordHeader recordId={recordId} handleOptionOpen={() => {}} />
+      <RecordHeader recordId={recordId} />
       <Accordion
         type="single"
         defaultValue="stats"

--- a/src/components/record/index.tsx
+++ b/src/components/record/index.tsx
@@ -8,6 +8,7 @@ import { RecordOptions } from "@/components/record/options";
 import { RecordOptionsSummary } from "@/components/record/options/summary";
 import { RecordPanels } from "@/components/record/panels";
 import { RecordPreview } from "@/components/record/preview";
+import { SetOptions } from "@/components/record/set-options";
 import {
   Accordion,
   AccordionContent,
@@ -16,7 +17,7 @@ import {
 } from "@/components/ui/accordion";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
-import { Dialog } from "@/components/ui/dialog";
+import { Dialog, DialogTrigger } from "@/components/ui/dialog";
 import { useRecord } from "@/hooks/use-data";
 import { recordActions } from "@/lib/features/record/record-slice";
 import { useAppDispatch, useAppSelector } from "@/lib/redux/hooks";
@@ -118,9 +119,14 @@ const Interval = ({
         </AccordionItem>
       </Accordion>
       <div className="fixed bottom-[calc(env(safe-area-inset-bottom)+1rem)] w-full px-4">
-        <Button size="lg" className="w-full">
-          新的一局
-        </Button>
+        <Dialog>
+          <DialogTrigger asChild>
+            <Button size="lg" className="w-full">
+              新的一局
+            </Button>
+          </DialogTrigger>
+          <SetOptions recordId={recordId} setIndex={setIndex + 1} />
+        </Dialog>
       </div>
     </>
   );

--- a/src/components/record/index.tsx
+++ b/src/components/record/index.tsx
@@ -1,11 +1,19 @@
 "use client";
 import LoadingCard from "@/components/custom/loading/card";
 import LoadingCourt from "@/components/custom/loading/court";
+import { StatsForOneSet } from "@/components/match/stats";
 import { RecordCourt } from "@/components/record/court";
 import { RecordHeader } from "@/components/record/header";
 import { RecordOptions } from "@/components/record/options";
 import { RecordPanels } from "@/components/record/panels";
 import { RecordPreview } from "@/components/record/preview";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Dialog } from "@/components/ui/dialog";
 import { useRecord } from "@/hooks/use-data";
@@ -24,7 +32,7 @@ const Record = ({
   const dispatch = useAppDispatch();
   const [dialogOpen, setDialogOpen] = useState(false);
   const [tabValue, setTabValue] = useState("overview");
-  const { _id } = useAppSelector((state) => state.record);
+  const { _id, general } = useAppSelector((state) => state.record);
 
   const handleOptionOpen = (tabValue: string) => {
     dispatch(recordActions.initialize({ record, setIndex }));
@@ -50,6 +58,10 @@ const Record = ({
     );
   }
 
+  if (!general.status.inProgress) {
+    return <Interval recordId={recordId} setIndex={setIndex} />;
+  }
+
   return (
     <>
       <RecordHeader recordId={recordId} handleOptionOpen={handleOptionOpen} />
@@ -71,6 +83,42 @@ const Record = ({
           setTabValue={setTabValue}
         />
       </Dialog>
+    </>
+  );
+};
+
+const Interval = ({
+  recordId,
+  setIndex,
+}: {
+  recordId: string;
+  setIndex: number;
+}) => {
+  return (
+    <>
+      <RecordHeader recordId={recordId} handleOptionOpen={() => {}} />
+      <Accordion
+        type="single"
+        defaultValue="stats"
+        collapsible
+        className="w-full bg-card mb-[calc(env(safe-area-inset-bottom)+5.5rem)]"
+      >
+        <AccordionItem value="stats" className="w-full">
+          <AccordionTrigger className="w-full p-4">數據統計</AccordionTrigger>
+          <AccordionContent className="flex w-full flex-col items-center justify-center gap-4">
+            <StatsForOneSet recordId={recordId} setIndex={setIndex} />
+          </AccordionContent>
+        </AccordionItem>
+        <AccordionItem value="summary" className="w-full">
+          <AccordionTrigger className="w-full p-4">逐球紀錄</AccordionTrigger>
+          <AccordionContent className="w-full"></AccordionContent>
+        </AccordionItem>
+      </Accordion>
+      <div className="absolute bottom-[calc(env(safe-area-inset-bottom)+1rem)] w-full px-4">
+        <Button size="lg" className="w-full">
+          新的一局
+        </Button>
+      </div>
     </>
   );
 };

--- a/src/components/record/index.tsx
+++ b/src/components/record/index.tsx
@@ -5,6 +5,7 @@ import { StatsForOneSet } from "@/components/match/stats";
 import { RecordCourt } from "@/components/record/court";
 import { RecordHeader } from "@/components/record/header";
 import { RecordOptions } from "@/components/record/options";
+import { RecordOptionsSummary } from "@/components/record/options/summary";
 import { RecordPanels } from "@/components/record/panels";
 import { RecordPreview } from "@/components/record/preview";
 import {
@@ -47,14 +48,14 @@ const Record = ({
   if (error) throw error;
   if (isLoading || _id !== recordId) {
     return (
-      <>
+      <div className="flex size-full max-w-[640px] flex-col items-center justify-start gap-1 overflow-hidden">
         <RecordHeader />
         <LoadingCourt />
         <Card className="grid w-full p-2">
           <div className="h-8 rounded-md bg-muted motion-safe:animate-pulse" />
         </Card>
         <LoadingCard className="w-full flex-1 pb-4" />
-      </>
+      </div>
     );
   }
 
@@ -63,7 +64,7 @@ const Record = ({
   }
 
   return (
-    <>
+    <div className="flex size-full max-w-[640px] flex-col items-center justify-start gap-1 overflow-hidden">
       <RecordHeader recordId={recordId} handleOptionOpen={handleOptionOpen} />
       <RecordCourt recordId={recordId} mode="general" />
       <RecordPreview
@@ -83,7 +84,7 @@ const Record = ({
           setTabValue={setTabValue}
         />
       </Dialog>
-    </>
+    </div>
   );
 };
 
@@ -101,20 +102,22 @@ const Interval = ({
         type="single"
         defaultValue="stats"
         collapsible
-        className="w-full bg-card mb-[calc(env(safe-area-inset-bottom)+5.5rem)]"
+        className="w-full pb-[calc(env(safe-area-inset-bottom)+5.5rem)]"
       >
-        <AccordionItem value="stats" className="w-full">
+        <AccordionItem value="stats" className="w-full bg-card">
           <AccordionTrigger className="w-full p-4">數據統計</AccordionTrigger>
           <AccordionContent className="flex w-full flex-col items-center justify-center gap-4">
             <StatsForOneSet recordId={recordId} setIndex={setIndex} />
           </AccordionContent>
         </AccordionItem>
-        <AccordionItem value="summary" className="w-full">
+        <AccordionItem value="summary" className="w-full bg-card">
           <AccordionTrigger className="w-full p-4">逐球紀錄</AccordionTrigger>
-          <AccordionContent className="w-full"></AccordionContent>
+          <AccordionContent className="h-full w-full px-4">
+            <RecordOptionsSummary recordId={recordId} />
+          </AccordionContent>
         </AccordionItem>
       </Accordion>
-      <div className="absolute bottom-[calc(env(safe-area-inset-bottom)+1rem)] w-full px-4">
+      <div className="fixed bottom-[calc(env(safe-area-inset-bottom)+1rem)] w-full px-4">
         <Button size="lg" className="w-full">
           新的一局
         </Button>

--- a/src/components/record/set-options/panels/index.tsx
+++ b/src/components/record/set-options/panels/index.tsx
@@ -13,7 +13,7 @@ export const SetOptionsPanels = ({ recordId }: { recordId: string }) => {
   const { optionMode } = useAppSelector((state) => state.lineup.status);
 
   return (
-    <Panels>
+    <Panels className="overflow-hidden">
       {optionMode === LineupOptionMode.PLAYERINFO ? (
         <PlayerInfo members={record.teams.home.players} />
       ) : optionMode === LineupOptionMode.SUBSTITUTES ? (

--- a/src/components/record/set-options/panels/options.tsx
+++ b/src/components/record/set-options/panels/options.tsx
@@ -84,7 +84,7 @@ export const Options = ({ recordId }: { recordId: string }) => {
   }, [record, setIndex, defaultValues, form]);
 
   return (
-    <PanelContent>
+    <PanelContent className="overflow-y-hidden">
       <Dialog>
         <Form
           form={form}


### PR DESCRIPTION
This PR introduces a new `Interval` component that appears in the Record layout when a volleyball set concludes. The component enhances the user experience by providing a structured interface for post-set analysis and transitions.

Key Features:
- Implemented `Interval` component that replaces the main court view when a set ends
- Added an accordion-style interface with two main sections:
  - Statistics panel: Integrates with `StatsForOneSet` component to display team performance metrics
  - Rally summary panel: Prepared structure for detailed play-by-play review
- Included a prominent "New Set" button for seamless transition to the next set
- Integrated with existing record status management to handle set completion states

Technical Details:
- The component conditionally renders based on the `general.status.inProgress` flag
- Leverages existing `RecordHeader` component for consistent UI
- Utilizes the shadcn/ui accordion and button components for the interface
- Maintains mobile-friendly layout with safe-area considerations

This enhancement improves the overall match flow by providing a clear interface for reviewing set statistics and preparing for the next set.
<img width="500" height="880" alt="截圖 2025-08-01 晚上7 28 00" src="https://github.com/user-attachments/assets/11a68964-182f-4776-b1db-74c079122a8f" />
