### PR TITLE
fix(ui): remove fixed padding from Card in PanelContent

### DIFF
--- a/src/components/record/set-options/panel/options.tsx
+++ b/src/components/record/set-options/panel/options.tsx
@@ -24,7 +24,6 @@ import {
 } from "@/lib/features/record/types";
 import { useReplacePosition } from "@/lib/features/team/hooks/use-replace-position";
 import { useAppSelector } from "@/lib/redux/hooks";
-import { cn } from "@/lib/utils";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useRouter } from "next/navigation";
 import { useEffect, useMemo } from "react";
@@ -83,7 +82,7 @@ export const Options = ({ recordId }: { recordId: string }) => {
 
   return (
     <PanelContent className="overflow-y-hidden">
-      <Card>
+      <Card className="p-0 overflow-y-hidden">
         <Dialog>
           <Form
             form={form}
@@ -113,12 +112,8 @@ export const Options = ({ recordId }: { recordId: string }) => {
 
 const ServingTeam = ({ form }) => {
   return (
-    <section
-      className={cn(
-        "flex w-full flex-col items-center justify-center gap-2 pt-2",
-      )}
-    >
-      <CardHeader>
+    <section className="flex w-full flex-col items-center justify-center gap-2 pt-2">
+      <CardHeader className="w-full">
         <CardTitle>本局發球權</CardTitle>
       </CardHeader>
       <FormField
@@ -150,12 +145,8 @@ const SubstitutesTable = ({ members }: { members: Player[] }) => {
   const substituteLimit = liberoCount < 2 ? 6 - liberoCount : 6;
 
   return (
-    <section
-      className={cn(
-        "flex w-full flex-col items-center justify-center gap-2 pt-2",
-      )}
-    >
-      <CardHeader>
+    <section className="flex w-full flex-col items-center justify-center gap-2 pt-2">
+      <CardHeader className="w-full">
         <CardTitle>
           替補名單 ({substituteCount}/{substituteLimit})
         </CardTitle>

--- a/src/components/record/set-options/panel/substitutes.tsx
+++ b/src/components/record/set-options/panel/substitutes.tsx
@@ -16,7 +16,7 @@ export const Substitutes = ({ recordId }: { recordId: string }) => {
 
   return (
     <PanelContent>
-      <Card>
+      <Card className="p-0">
         <CardHeader>
           <Button
             variant="ghost"

--- a/src/components/team/lineup/panel/options/index.tsx
+++ b/src/components/team/lineup/panel/options/index.tsx
@@ -42,7 +42,7 @@ export const LineupOptions = ({ members, others, hasPairedSwitchPosition }) => {
 
   return (
     <PanelContent>
-      <Card>
+      <Card className="p-0">
         <CardHeader>
           <CardTitle>陣容配置 {status.lineupIndex + 1}</CardTitle>
           <div className="flex flex-1 flex-row items-center justify-end gap-2">

--- a/src/components/team/lineup/panel/options/libero-replace.tsx
+++ b/src/components/team/lineup/panel/options/libero-replace.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
-import { Card, CardHeader, CardTitle } from "@/components/ui/card";
+import { CardHeader, CardTitle } from "@/components/ui/card";
 import {
   DialogClose,
   DialogContent,
@@ -31,7 +31,6 @@ import {
   type LiberoReplaceFormValues,
 } from "@/lib/features/team/types";
 import { useAppDispatch } from "@/lib/redux/hooks";
-import { cn } from "@/lib/utils";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useEffect } from "react";
 import { useForm } from "react-hook-form";
@@ -46,12 +45,8 @@ export const LiberoReplaceTrigger = () => {
     useReplacePosition();
 
   return (
-    <section
-      className={cn(
-        "flex w-full flex-col items-center justify-center gap-2 pt-2",
-      )}
-    >
-      <CardHeader>
+    <section className="flex w-full flex-col items-center justify-center gap-2 pt-2">
+      <CardHeader className="w-full">
         <CardTitle>自由球員設定</CardTitle>
       </CardHeader>
       {!!liberoReplaceMode && !hasPairedReplacePosition && (

--- a/src/components/team/lineup/panel/player-info.tsx
+++ b/src/components/team/lineup/panel/player-info.tsx
@@ -26,7 +26,7 @@ export const PlayerInfo = ({ members }: { members: Player[] }) => {
 
   return (
     <PanelContent>
-      <Card>
+      <Card className="p-0">
         <CardHeader>
           <Button
             variant="ghost"

--- a/src/components/team/lineup/panel/positions.tsx
+++ b/src/components/team/lineup/panel/positions.tsx
@@ -40,7 +40,7 @@ export const Positions = () => {
 
   return (
     <PanelContent>
-      <Card>
+      <Card className="p-0">
         <CardHeader>
           <Button
             variant="ghost"

--- a/src/components/team/lineup/panel/substitutes.tsx
+++ b/src/components/team/lineup/panel/substitutes.tsx
@@ -51,7 +51,7 @@ export const Substitutes = ({ members, others }) => {
 
   return (
     <PanelContent>
-      <Card>
+      <Card className="p-0">
         <CardHeader>
           <Button
             variant="ghost"


### PR DESCRIPTION
# 修正卡片元件佈局問題

## 變更內容
- 移除 PanelContent 中 Card 元件的固定內邊距
- 為 Card 元件添加 `p-0` class 以確保一致的佈局
- 清理冗餘的 className 串接
- 修正設定面板的溢出處理

## 更新的元件
- 局次設定面板 Set Options Panel
- 陣容設定面板 Lineup Options Panel
- 球員資訊面板 Player Info Panel
- 位置面板 Positions Panel
- 替補面板 Substitutes Panel
- 自由球員替換面板 Libero Replace Panel

## 技術細節
- 移除不必要的 `cn` 工具函數使用，改用簡單的 className 字串
- 增加適當的溢出處理以防止佈局問題
- 統一各元件的 Card 內邊距處理方式