### PR TITLE
Fix ObjectId serialization causing team page failures

### DIFF
--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -62,7 +62,10 @@ const authConfig = {
         token.name = user.name;
         token.email = user.email;
         token.image = user.image;
-        token.teams = user.teams;
+        token.teams = user.teams ? {
+          joined: user.teams.joined?.map(id => id.toString()) || [],
+          inviting: user.teams.inviting?.map(id => id.toString()) || []
+        } : { joined: [], inviting: [] };
       }
       if (trigger === "update") {
         return { ...token, user: session?.user };
@@ -74,7 +77,7 @@ const authConfig = {
       session.user.name = token.name;
       session.user.email = token.email;
       session.user.image = token.image;
-      session.user.teams = token.teams;
+      session.user.teams = token.teams || { joined: [], inviting: [] };
       return session;
     },
   },


### PR DESCRIPTION
## Summary

🐛 **Fix Critical Bug**: Resolves ObjectId serialization issue in NextAuth callbacks that was causing team page and home page failures.

**Root Cause**: MongoDB `ObjectId` objects were not being properly converted to strings in NextAuth JWT/session callbacks, resulting in `"[object Object]"` being passed as `teamId` parameters to API routes.

**Impact**: 
- ✅ Home page match records now display correctly
- ✅ Team pages load without Application errors
- ✅ Fixes production environment crashes

## Changes Made

- **Enhanced NextAuth callbacks** in `src/auth.config.ts`:
  - Convert `user.teams.joined` ObjectId array to string array
  - Convert `user.teams.inviting` ObjectId array to string array  
  - Add fallback handling for undefined teams object
  - Ensure proper serialization for client-side consumption

## Technical Details

**Before**:
```typescript
token.teams = user.teams; // ObjectId objects passed directly
```

**After**:
```typescript
token.teams = user.teams ? {
  joined: user.teams.joined?.map(id => id.toString()) || [],
  inviting: user.teams.inviting?.map(id => id.toString()) || []
} : { joined: [], inviting: [] };
```

## Test Results

- ✅ All tests pass (171 tests: 135 passed, 36 skipped)
- ✅ No ESLint errors or warnings
- ✅ Build successful with no TypeScript errors
- ✅ Verified fix resolves the CastError in API routes

## Related Issue

Fixes #239

---

## 概要

🐛 **重大錯誤修復**: 解決 NextAuth 回調函式中 ObjectId 序列化問題，該問題導致隊伍頁面和首頁故障。

**根本原因**: MongoDB `ObjectId` 物件在 NextAuth JWT/session 回調函式中未正確轉換為字串，導致 `"[object Object]"` 被作為 `teamId` 參數傳遞給 API 路由。

**影響範圍**: 
- ✅ 首頁比賽紀錄現可正確顯示
- ✅ 隊伍頁面載入無應用程式錯誤
- ✅ 修復生產環境崩潰問題

## 變更內容

- **增強 NextAuth 回調函式** 於 `src/auth.config.ts`:
  - 將 `user.teams.joined` ObjectId 陣列轉換為字串陣列
  - 將 `user.teams.inviting` ObjectId 陣列轉換為字串陣列
  - 為未定義的 teams 物件新增備援處理
  - 確保客戶端使用的正確序列化

## 技術細節

**修復前**:
```typescript
token.teams = user.teams; // ObjectId 物件直接傳遞
```

**修復後**:
```typescript
token.teams = user.teams ? {
  joined: user.teams.joined?.map(id => id.toString()) || [],
  inviting: user.teams.inviting?.map(id => id.toString()) || []
} : { joined: [], inviting: [] };
```

## 測試結果

- ✅ 所有測試通過 (171 項測試: 135 通過, 36 跳過)
- ✅ 無 ESLint 錯誤或警告
- ✅ 建置成功，無 TypeScript 錯誤
- ✅ 已驗證修復解決 API 路由中的 CastError

## 相關 Issue

修復 #239