### PR TITLE
feat(spec-pages): show archived changes in separate section

### DIFF
--- a/.github/workflows/spec-pages.yml
+++ b/.github/workflows/spec-pages.yml
@@ -41,11 +41,13 @@ jobs:
 
           BUILD   = pathlib.Path(".pages-build")
           CHANGES = pathlib.Path("docs/changes")
+          ARCHIVE = CHANGES / "archive"
           SHELL   = pathlib.Path("docs/shell.html")
           repo    = os.environ.get("GH_REPO", "")
 
           BUILD.mkdir(exist_ok=True)
           (BUILD / "changes").mkdir(exist_ok=True)
+          (BUILD / "changes" / "archive").mkdir(exist_ok=True)
 
           if SHELL.exists():
               shutil.copy(SHELL, BUILD / "shell.html")
@@ -54,103 +56,164 @@ jobs:
               if s is None: return ""
               return str(s).replace("&","&amp;").replace("<","&lt;").replace(">","&gt;").replace('"',"&quot;")
 
-          manifests = []
-
-          for cdir in sorted(p for p in CHANGES.iterdir() if p.is_dir()):
-              # Skip directories that aren't changes (e.g. stale specs/ at root level)
-              if not any((cdir / f).exists() for f in ["meta.json", "proposal.md", "proposal.html"]):
-                  continue
-              name = cdir.name
-              cb   = BUILD / "changes" / name
-              cb.mkdir(exist_ok=True)
-
-              # Copy HTML + MD artifacts
+          def copy_artifacts(cdir, cb):
+              cb.mkdir(parents=True, exist_ok=True)
               for stem in ["proposal", "design", "mockup", "review", "tasks"]:
                   for ext in [".html", ".md"]:
                       src = cdir / (stem + ext)
-                      if src.exists():
-                          shutil.copy(src, cb)
-
-              # Copy specs subtree
+                      if src.exists(): shutil.copy(src, cb)
               specs_src = cdir / "specs"
               if specs_src.exists():
                   shutil.copytree(specs_src, cb / "specs", dirs_exist_ok=True)
 
-              # Read meta.json (human-authored: summary, dates, PR info)
+          def make_manifest(cdir, name, arch_date=None):
               meta = {}
               if (cdir / "meta.json").exists():
                   meta = json.loads((cdir / "meta.json").read_text())
-
-              # Count tasks
               total = done = 0
-              tasks_file = cdir / "tasks.md"
-              if tasks_file.exists():
-                  src_text = tasks_file.read_text()
-                  total = len(re.findall(r'^\s*- \[[ xX]\]', src_text, re.MULTILINE))
-                  done  = len(re.findall(r'^\s*- \[[xX]\]',  src_text, re.MULTILINE))
-
-              def art(stem):
-                  return {"html": (cdir / f"{stem}.html").exists(),
-                          "md":   (cdir / f"{stem}.md").exists()}
-
-              specs_list = []
+              tf = cdir / "tasks.md"
+              if tf.exists():
+                  t = tf.read_text()
+                  total = len(re.findall(r'^\s*- \[[ xX]\]', t, re.MULTILINE))
+                  done  = len(re.findall(r'^\s*- \[[xX]\]',  t, re.MULTILINE))
+              def art(s): return {"html":(cdir/f"{s}.html").exists(),"md":(cdir/f"{s}.md").exists()}
+              specs_src = cdir / "specs"
+              specs = []
               if specs_src.exists():
                   for sd in sorted(p for p in specs_src.iterdir() if p.is_dir()):
-                      specs_list.append({"name": sd.name,
-                                         "html": (sd / "spec.html").exists()})
+                      specs.append({"name": sd.name, "html": (sd/"spec.html").exists()})
+              m = {"name":name,"summary":meta.get("summary",""),"proposedAt":meta.get("proposedAt"),
+                   "prNumber":meta.get("prNumber"),"prCreatedAt":meta.get("prCreatedAt"),
+                   "done":done,"total":total,
+                   "artifacts":{"proposal":art("proposal"),"design":art("design"),"review":art("review")},
+                   "specs":specs}
+              if arch_date: m["archivedAt"] = arch_date
+              return m
 
-              manifest = {
-                  "name":        name,
-                  "summary":     meta.get("summary", ""),
-                  "proposedAt":  meta.get("proposedAt"),
-                  "prNumber":    meta.get("prNumber"),
-                  "prCreatedAt": meta.get("prCreatedAt"),
-                  "done":        done,
-                  "total":       total,
-                  "artifacts": {
-                      "proposal": art("proposal"),
-                      "design":   art("design"),
-                      "review":   art("review"),
-                  },
-                  "specs": specs_list,
-              }
+          # -- Active changes --
+          manifests = []
+          for cdir in sorted(p for p in CHANGES.iterdir() if p.is_dir() and p.name != "archive"):
+              if not any((cdir / f).exists() for f in ["meta.json", "proposal.md", "proposal.html"]):
+                  continue
+              name = cdir.name
+              cb   = BUILD / "changes" / name
+              copy_artifacts(cdir, cb)
+              manifest = make_manifest(cdir, name)
               (cb / "manifest.json").write_text(json.dumps(manifest, indent=2))
               manifests.append(manifest)
 
-          # ── index.html ──────────────────────────────────────────────────────
+          # -- Archived changes --
+          archived = []
+          if ARCHIVE.exists():
+              for cdir in sorted((p for p in ARCHIVE.iterdir() if p.is_dir()), reverse=True):
+                  mm = re.match(r'^(\d{4}-\d{2}-\d{2})-(.+)$', cdir.name)
+                  arch_date = mm.group(1) if mm else None
+                  name      = mm.group(2) if mm else cdir.name
+                  cb = BUILD / "changes" / "archive" / cdir.name
+                  copy_artifacts(cdir, cb)
+                  manifest = make_manifest(cdir, name, arch_date)
+                  (cb / "manifest.json").write_text(json.dumps(manifest, indent=2))
+                  archived.append((cdir.name, manifest))
+
+          # -- index.html --
+          def pr_link(m):
+              if not m.get("prNumber"): return ""
+              pr_url = f"https://github.com/{repo}/pull/{m['prNumber']}"
+              return f'<a class="pr-badge" href="{esc(pr_url)}" target="_blank" rel="noopener" onclick="event.stopPropagation()">PR #{esc(str(m["prNumber"]))}</a>'
+
           cards = ""
           for m in manifests:
               name = m["name"]
               pct  = round(m["done"] / m["total"] * 100) if m["total"] else 0
-
-              pr_badge = ""
-              if m.get("prNumber"):
-                  pr_url = f"https://github.com/{repo}/pull/{m['prNumber']}"
-                  pr_badge = f'<a class="pr-badge" href="{esc(pr_url)}" target="_blank" rel="noopener" onclick="event.stopPropagation()">PR #{esc(str(m["prNumber"]))}</a>'
-
               meta_parts = []
-              if m.get("proposedAt"):
-                  meta_parts.append(f'<span>Proposed {esc(m["proposedAt"])}</span>')
-              if m.get("prCreatedAt"):
-                  meta_parts.append(f'<span>PR opened {esc(m["prCreatedAt"])}</span>')
+              if m.get("proposedAt"):  meta_parts.append(f'<span>Proposed {esc(m["proposedAt"])}</span>')
+              if m.get("prCreatedAt"): meta_parts.append(f'<span>PR opened {esc(m["prCreatedAt"])}</span>')
               meta_row = " · ".join(meta_parts)
-
               card_url = f"shell.html?change={esc(name)}"
               cards += f"""
           <div class="card" role="link" tabindex="0" onclick="location.href='{card_url}'" onkeydown="if(event.key==='Enter')location.href='{card_url}'">
-            <div class="card-top">
-              <span class="card-name">{esc(name)}</span>
-              {pr_badge}
-            </div>
+            <div class="card-top"><span class="card-name">{esc(name)}</span>{pr_link(m)}</div>
             <p class="card-sum">{esc(m.get("summary",""))}</p>
             <div class="card-meta">{meta_row}</div>
-            <div class="prog-row" role="progressbar" aria-valuenow="{m['done']}" aria-valuemin="0" aria-valuemax="{m['total']}" aria-label="{m['done']} of {m['total']} tasks done">
+            <div class="prog-row" role="progressbar" aria-valuenow="{m['done']}" aria-valuemin="0" aria-valuemax="{m['total']}">
               <div class="prog-track"><div class="prog-fill" style="width:{pct}%"></div></div>
               <span class="prog-label">{m['done']}/{m['total']} tasks</span>
             </div>
           </div>"""
 
+          arc_rows = ""
+          for dir_name, m in archived:
+              name = m["name"]
+              card_url = f"shell.html?change=archive/{esc(dir_name)}"
+              arc_rows += f"""
+          <div class="arc-row" role="link" tabindex="0" onclick="location.href='{card_url}'" onkeydown="if(event.key==='Enter')location.href='{card_url}'">
+            <span class="arc-name">{esc(name)}</span>
+            <span class="arc-sum">{esc(m.get("summary",""))}</span>
+            <span class="arc-date">{esc(m.get("archivedAt",""))}</span>
+            {pr_link(m)}
+          </div>"""
+
+          arc_section = ""
+          if archived:
+              arc_section = f"""
+          <div class="sec-hd">
+            <span class="sec-title">Archived</span><span class="sec-count">{len(archived)}</span>
+            <span class="sec-rule"></span>
+          </div>
+          <div class="arc-list">{arc_rows}
+          </div>"""
+
+          active_section = f'<div class="grid">{cards}\n          </div>' if manifests else '<p class="empty">No active changes.</p>'
+
           now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+          CSS = """
+          :root{--bg:#0c0c10;--surface:#14141c;--border:#22222e;--text:#e2e2f0;--muted:#7878a0;--accent:#818cf8}
+          @media(prefers-color-scheme:light){:root{--bg:#f4f4f9;--surface:#ffffff;--border:#dddde8;--text:#1a1a2e;--muted:#6868a0;--accent:#6366f1}}
+          [data-theme=dark]{--bg:#0c0c10;--surface:#14141c;--border:#22222e;--text:#e2e2f0;--muted:#7878a0;--accent:#818cf8}
+          [data-theme=light]{--bg:#f4f4f9;--surface:#ffffff;--border:#dddde8;--text:#1a1a2e;--muted:#6868a0;--accent:#6366f1}
+          *{box-sizing:border-box}
+          body{margin:0;font:15px/1.65 'Bricolage Grotesque',system-ui,sans-serif;background:var(--bg);color:var(--text);-webkit-font-smoothing:antialiased}
+          main{max-width:900px;margin:0 auto;padding:40px 20px 72px}
+          .hd{display:flex;align-items:baseline;gap:12px;margin-bottom:32px}
+          h1{font-size:26px;font-weight:700;margin:0;letter-spacing:-.4px}
+          .sub{color:var(--muted);font-size:13px;margin:0;font-family:'IBM Plex Mono',monospace}
+          .grid{display:flex;flex-direction:column;gap:10px}
+          .card{cursor:pointer;background:var(--surface);border:1px solid var(--border);border-radius:12px;padding:18px 20px;transition:border-color .14s,box-shadow .14s}
+          .card:hover,.card:focus-visible{border-color:var(--accent);box-shadow:0 0 0 3px color-mix(in srgb,var(--accent) 12%,transparent);outline:none}
+          .card-top{display:flex;align-items:center;gap:8px;margin-bottom:6px}
+          .card-name{font-weight:600;font-size:15px;flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-family:'IBM Plex Mono',monospace;letter-spacing:-.3px}
+          .pr-badge{font-size:11px;font-weight:500;color:var(--accent);border:1px solid color-mix(in srgb,var(--accent) 50%,transparent);border-radius:5px;padding:2px 8px;white-space:nowrap;text-decoration:none;flex-shrink:0;font-family:'IBM Plex Mono',monospace;transition:background .12s,color .12s}
+          .pr-badge:hover{background:var(--accent);color:var(--bg)}
+          .card-sum{margin:0 0 10px;font-size:13.5px;color:var(--muted);line-height:1.5;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden}
+          .card-meta{font-size:12px;color:var(--muted);margin-bottom:12px;font-family:'IBM Plex Mono',monospace}
+          .prog-row{display:flex;align-items:center;gap:10px}
+          .prog-track{flex:1;max-width:240px;height:3px;background:var(--border);border-radius:2px;overflow:hidden}
+          .prog-fill{height:100%;background:var(--accent);border-radius:2px}
+          .prog-label{font-size:11px;color:var(--muted);font-family:'IBM Plex Mono',monospace;white-space:nowrap}
+          .sec-hd{display:flex;align-items:center;gap:8px;margin:40px 0 10px}
+          .sec-title{font-size:11px;font-weight:600;letter-spacing:.1em;text-transform:uppercase;color:var(--muted);font-family:'IBM Plex Mono',monospace;white-space:nowrap}
+          .sec-count{font-family:'IBM Plex Mono',monospace;font-size:11px;background:var(--border);color:var(--muted);border-radius:10px;padding:1px 7px;flex-shrink:0}
+          .sec-rule{flex:1;height:1px;background:var(--border)}
+          .arc-list{display:flex;flex-direction:column}
+          .arc-row{cursor:pointer;display:flex;align-items:center;gap:14px;padding:9px 14px 9px 16px;border-radius:7px;border-left:2px solid transparent;transition:border-left-color .14s,background .14s}
+          .arc-row:hover,.arc-row:focus-visible{border-left-color:var(--accent);background:color-mix(in srgb,var(--surface) 60%,var(--bg));outline:none}
+          .arc-name{font-family:'IBM Plex Mono',monospace;font-size:12.5px;font-weight:500;color:var(--muted);white-space:nowrap;flex-shrink:0;width:200px;overflow:hidden;text-overflow:ellipsis}
+          .arc-sum{font-size:13px;color:var(--muted);opacity:.55;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;flex:1;min-width:0}
+          .arc-date{font-family:'IBM Plex Mono',monospace;font-size:11px;color:var(--muted);opacity:.45;white-space:nowrap;flex-shrink:0}
+          .empty{color:var(--muted);font-size:14px}
+          .theme-pill{position:fixed;top:14px;right:18px;appearance:none;background:var(--surface);border:1px solid var(--border);cursor:pointer;font-size:13px;padding:3px 10px;border-radius:20px;color:var(--muted);transition:border-color .12s;line-height:1.6;font-family:'Bricolage Grotesque',system-ui,sans-serif}
+          .theme-pill:hover{border-color:var(--accent);color:var(--text)}
+          """
+          JS = """
+          (function(){
+            var btn=document.createElement('button');btn.className='theme-pill';btn.title='Toggle theme';btn.setAttribute('aria-label','Toggle theme');
+            var sys=function(){return window.matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light';};
+            var apply=function(t){document.documentElement.dataset.theme=t;btn.textContent=t==='dark'?'☀':'☾';};
+            document.addEventListener('DOMContentLoaded',function(){document.body.appendChild(btn);});
+            apply(localStorage.getItem('theme')||sys());
+            btn.onclick=function(){var n=document.documentElement.dataset.theme==='dark'?'light':'dark';localStorage.setItem('theme',n);apply(n);};
+          })();
+          """
           index = f"""<!doctype html>
           <html lang="en">
           <head>
@@ -160,54 +223,18 @@ jobs:
           <link rel="preconnect" href="https://fonts.googleapis.com">
           <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
           <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400;12..96,500;12..96,600;12..96,700&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet">
-          <style>
-          :root{{--bg:#0c0c10;--surface:#14141c;--border:#22222e;--text:#e2e2f0;--muted:#7878a0;--accent:#818cf8}}
-          @media(prefers-color-scheme:light){{:root{{--bg:#f4f4f9;--surface:#ffffff;--border:#dddde8;--text:#1a1a2e;--muted:#6868a0;--accent:#6366f1}}}}
-          [data-theme=dark]{{--bg:#0c0c10;--surface:#14141c;--border:#22222e;--text:#e2e2f0;--muted:#7878a0;--accent:#818cf8}}
-          [data-theme=light]{{--bg:#f4f4f9;--surface:#ffffff;--border:#dddde8;--text:#1a1a2e;--muted:#6868a0;--accent:#6366f1}}
-          *{{box-sizing:border-box}}
-          body{{margin:0;font:15px/1.65 'Bricolage Grotesque',system-ui,sans-serif;background:var(--bg);color:var(--text);-webkit-font-smoothing:antialiased}}
-          main{{max-width:900px;margin:0 auto;padding:40px 20px 72px}}
-          .hd{{display:flex;align-items:baseline;gap:12px;margin-bottom:32px}}
-          h1{{font-size:26px;font-weight:700;margin:0;letter-spacing:-.4px}}
-          .sub{{color:var(--muted);font-size:13px;margin:0;font-family:'IBM Plex Mono',monospace}}
-          .grid{{display:flex;flex-direction:column;gap:10px}}
-          .card{{cursor:pointer;background:var(--surface);border:1px solid var(--border);border-radius:12px;padding:18px 20px;transition:border-color .14s,box-shadow .14s}}
-          .card:hover,.card:focus-visible{{border-color:var(--accent);box-shadow:0 0 0 3px color-mix(in srgb,var(--accent) 12%,transparent);outline:none}}
-          .card-top{{display:flex;align-items:center;gap:8px;margin-bottom:6px}}
-          .card-name{{font-weight:600;font-size:15px;flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-family:'IBM Plex Mono',monospace;letter-spacing:-.3px}}
-          .pr-badge{{font-size:11px;font-weight:500;color:var(--accent);border:1px solid color-mix(in srgb,var(--accent) 50%,transparent);border-radius:5px;padding:2px 8px;white-space:nowrap;text-decoration:none;flex-shrink:0;font-family:'IBM Plex Mono',monospace;transition:background .12s,color .12s}}
-          .pr-badge:hover{{background:var(--accent);color:var(--bg)}}
-          .card-sum{{margin:0 0 10px;font-size:13.5px;color:var(--muted);line-height:1.5;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden}}
-          .card-meta{{font-size:12px;color:var(--muted);margin-bottom:12px;font-family:'IBM Plex Mono',monospace}}
-          .prog-row{{display:flex;align-items:center;gap:10px}}
-          .prog-track{{flex:1;max-width:240px;height:3px;background:var(--border);border-radius:2px;overflow:hidden}}
-          .prog-fill{{height:100%;background:var(--accent);border-radius:2px}}
-          .prog-label{{font-size:11px;color:var(--muted);font-family:'IBM Plex Mono',monospace;white-space:nowrap}}
-          .theme-pill{{position:fixed;top:14px;right:18px;appearance:none;background:var(--surface);border:1px solid var(--border);cursor:pointer;font-size:13px;padding:3px 10px;border-radius:20px;color:var(--muted);transition:border-color .12s;line-height:1.6;font-family:'Bricolage Grotesque',system-ui,sans-serif}}
-          .theme-pill:hover{{border-color:var(--accent);color:var(--text)}}
-          </style>
-          <script>
-          (function(){{
-            var btn=document.createElement('button');btn.className='theme-pill';btn.title='Toggle theme';btn.setAttribute('aria-label','Toggle theme');
-            var sys=function(){{return window.matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light';}};
-            var apply=function(t){{document.documentElement.dataset.theme=t;btn.textContent=t==='dark'?'☀':'☾';}};
-            document.addEventListener('DOMContentLoaded',function(){{document.body.appendChild(btn);}});
-            apply(localStorage.getItem('theme')||sys());
-            btn.onclick=function(){{var n=document.documentElement.dataset.theme==='dark'?'light':'dark';localStorage.setItem('theme',n);apply(n);}};
-          }})();
-          </script>
+          <style>{CSS}</style>
+          <script>{JS}</script>
           </head>
           <body>
           <main>
             <div class="hd"><h1>Spec Changes</h1><p class="sub">updated {now}</p></div>
-            <div class="grid">{cards}
-            </div>
+            {active_section}{arc_section}
           </main>
           </body>
           </html>"""
           (BUILD / "index.html").write_text(index)
-          print(f"Built {len(manifests)} change(s) into {BUILD}/")
+          print(f"Built {len(manifests)} active + {len(archived)} archived into .pages-build/")
           PYEOF
 
       - uses: actions/configure-pages@v5

--- a/.github/workflows/spec-pages.yml
+++ b/.github/workflows/spec-pages.yml
@@ -86,7 +86,7 @@ jobs:
                   hm = re.match(r"^(#{1,4})\s+(.*)", l)
                   if hm:
                       lvl  = len(hm.group(1))
-                      body += f"<h{lvl}>{esc_h(hm.group(2))}</h{lvl}>"
+                      body += "<h{0}>{1}</h{0}>".format(lvl, esc_h(hm.group(2)))
                       i += 1; continue
                   tm = re.match(r"^\s*[-*]\s+\[([ xX])\]\s+(.*)", l)
                   if tm:
@@ -94,7 +94,7 @@ jobs:
                       text = esc_h(tm.group(2))
                       cls  = "task done" if done else "task"
                       box  = "✓" if done else "☐"
-                      body += f'<li class="{cls}"><span class="box">{box}</span> {text}</li>'
+                      body += '<li class="{0}"><span class="box">{1}</span> {2}</li>'.format(cls, box, text)
                       i += 1; continue
                   bm = re.match(r"^>\s?(.*)", l)
                   if bm:
@@ -104,53 +104,73 @@ jobs:
                           i += 1
                       text = "\n".join(buf)
                       if text.upper().startswith("BLOCKED"):
-                          body += f'<details class="blocked" open><summary>{esc_h(text.split(chr(10))[0])}</summary></details>'
+                          body += '<details class="blocked" open><summary>{0}</summary></details>'.format(esc_h(text.split("\n")[0]))
                       else:
-                          body += f"<blockquote>{esc_h(text)}</blockquote>"
+                          body += "<blockquote>{0}</blockquote>".format(esc_h(text))
                       continue
                   if l.strip():
-                      body += f"<p>{esc_h(l)}</p>"
+                      body += "<p>{0}</p>".format(esc_h(l))
                   i += 1
 
-              tasks_html = f"""<!doctype html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Tasks</title>
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400;12..96,600;12..96,700&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet">
-<style>
-:root{{--bg:#0c0c10;--surface:#14141c;--border:#22222e;--text:#e2e2f0;--muted:#7878a0;--accent:#818cf8;--ok:#34d399;--bad:#f87171}}
-@media(prefers-color-scheme:light){{:root{{--bg:#f4f4f9;--surface:#ffffff;--border:#dddde8;--text:#1a1a2e;--muted:#6868a0;--accent:#6366f1;--ok:#059669;--bad:#dc2626}}}}
-[data-theme=dark]{{--bg:#0c0c10;--surface:#14141c;--border:#22222e;--text:#e2e2f0;--muted:#7878a0;--accent:#818cf8;--ok:#34d399;--bad:#f87171}}
-[data-theme=light]{{--bg:#f4f4f9;--surface:#ffffff;--border:#dddde8;--text:#1a1a2e;--muted:#6868a0;--accent:#6366f1;--ok:#059669;--bad:#dc2626}}
-*{{box-sizing:border-box}}
-body{{margin:0;font:15px/1.7 'Bricolage Grotesque',system-ui,sans-serif;background:var(--bg);color:var(--text);-webkit-font-smoothing:antialiased}}
-.wrap{{max-width:820px;margin:0 auto;padding:28px 20px 72px}}
-h2{{font-size:17px;font-weight:700;margin:28px 0 10px;padding-bottom:6px;border-bottom:1px solid var(--border)}}
-h3,h4{{font-size:14px;font-weight:600;margin:20px 0 6px;color:var(--muted)}}
-ul{{padding:0;list-style:none;margin:0}}
-li.task{{display:flex;align-items:baseline;gap:9px;padding:5px 0;font-size:14px;line-height:1.5}}
-li.task .box{{font-weight:700;font-family:'IBM Plex Mono',monospace;flex-shrink:0;min-width:1.2em;color:var(--muted)}}
-li.task.done .box{{color:var(--ok)}}
-li.task.done{{color:var(--muted);text-decoration:line-through;text-decoration-color:var(--border)}}
-details.blocked{{border:1px solid var(--bad);background:color-mix(in srgb,var(--bad) 8%,transparent);border-radius:8px;padding:10px 14px;margin:12px 0}}
-details.blocked summary{{color:var(--bad);font-weight:600;cursor:pointer;font-size:13px;font-family:'IBM Plex Mono',monospace}}
-blockquote{{border-left:3px solid var(--border);margin:10px 0;padding:3px 14px;color:var(--muted);font-size:13px}}
-p{{font-size:14px;color:var(--muted)}}
-</style>
-</head>
-<body>
-{HEADER_SCRIPT}
-<div class="wrap">
-{body}
-</div>
-</body>
-</html>"""
-              (cb / "tasks.html").write_text(tasks_html, "utf-8")
-
+              CSS = (
+                  ":root{--bg:#0c0c10;--surface:#14141c;--border:#22222e;--text:#e2e2f0;"
+                  "--muted:#7878a0;--accent:#818cf8;--ok:#34d399;--bad:#f87171}"
+                  "@media(prefers-color-scheme:light){:root{--bg:#f4f4f9;--surface:#ffffff;"
+                  "--border:#dddde8;--text:#1a1a2e;--muted:#6868a0;--accent:#6366f1;"
+                  "--ok:#059669;--bad:#dc2626}}"
+                  "[data-theme=dark]{--bg:#0c0c10;--surface:#14141c;--border:#22222e;"
+                  "--text:#e2e2f0;--muted:#7878a0;--accent:#818cf8;--ok:#34d399;--bad:#f87171}"
+                  "[data-theme=light]{--bg:#f4f4f9;--surface:#ffffff;--border:#dddde8;"
+                  "--text:#1a1a2e;--muted:#6868a0;--accent:#6366f1;--ok:#059669;--bad:#dc2626}"
+                  "*{box-sizing:border-box}"
+                  "body{margin:0;font:15px/1.7 'Bricolage Grotesque',system-ui,sans-serif;"
+                  "background:var(--bg);color:var(--text);-webkit-font-smoothing:antialiased}"
+                  ".wrap{max-width:820px;margin:0 auto;padding:28px 20px 72px}"
+                  "h2{font-size:17px;font-weight:700;margin:28px 0 10px;"
+                  "padding-bottom:6px;border-bottom:1px solid var(--border)}"
+                  "h3,h4{font-size:14px;font-weight:600;margin:20px 0 6px;color:var(--muted)}"
+                  "ul{padding:0;list-style:none;margin:0}"
+                  "li.task{display:flex;align-items:baseline;gap:9px;padding:5px 0;font-size:14px;line-height:1.5}"
+                  "li.task .box{font-weight:700;font-family:'IBM Plex Mono',monospace;"
+                  "flex-shrink:0;min-width:1.2em;color:var(--muted)}"
+                  "li.task.done .box{color:var(--ok)}"
+                  "li.task.done{color:var(--muted);text-decoration:line-through;"
+                  "text-decoration-color:var(--border)}"
+                  "details.blocked{border:1px solid var(--bad);"
+                  "background:color-mix(in srgb,var(--bad) 8%,transparent);"
+                  "border-radius:8px;padding:10px 14px;margin:12px 0}"
+                  "details.blocked summary{color:var(--bad);font-weight:600;"
+                  "cursor:pointer;font-size:13px;font-family:'IBM Plex Mono',monospace}"
+                  "blockquote{border-left:3px solid var(--border);margin:10px 0;"
+                  "padding:3px 14px;color:var(--muted);font-size:13px}"
+                  "p{font-size:14px;color:var(--muted)}"
+              )
+              FONTS = (
+                  "https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:"
+                  "opsz,wght@12..96,400;12..96,600;12..96,700"
+                  "&family=IBM+Plex+Mono:wght@400;500&display=swap"
+              )
+              parts = [
+                  "<!doctype html>",
+                  '<html lang="en">',
+                  "<head>",
+                  '<meta charset="utf-8">',
+                  '<meta name="viewport" content="width=device-width,initial-scale=1">',
+                  "<title>Tasks</title>",
+                  '<link rel="preconnect" href="https://fonts.googleapis.com">',
+                  '<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>',
+                  '<link href="' + FONTS + '" rel="stylesheet">',
+                  "<style>" + CSS + "</style>",
+                  "</head>",
+                  "<body>",
+                  HEADER_SCRIPT,
+                  '<div class="wrap">',
+                  body,
+                  "</div>",
+                  "</body>",
+                  "</html>",
+              ]
+              (cb / "tasks.html").write_text("\n".join(parts), "utf-8")
           def copy_artifacts(cdir, cb):
               cb.mkdir(parents=True, exist_ok=True)
               for stem in ["proposal", "design", "mockup", "review", "tasks"]:

--- a/.github/workflows/spec-pages.yml
+++ b/.github/workflows/spec-pages.yml
@@ -60,15 +60,15 @@ jobs:
               if s is None: return ""
               return str(s).replace("&","&amp;").replace("<","&lt;").replace(">","&gt;").replace('"',"&quot;")
 
-          HEADER_SCRIPT = '<script src="/header.js"></script>'
-
           def inject_header(cb):
-              """Inject /header.js into every artifact HTML except mockup.html."""
+              """Inject header.js (relative path) into every artifact HTML except mockup.html."""
               for f in cb.rglob("*.html"):
                   if f.name == "mockup.html": continue
                   text = f.read_text("utf-8")
-                  if "</body>" in text and HEADER_SCRIPT not in text:
-                      f.write_text(text.replace("</body>", HEADER_SCRIPT + "\n</body>", 1), "utf-8")
+                  if "</body>" not in text or "header.js" in text: continue
+                  depth = len(f.relative_to(BUILD).parts) - 1
+                  script = '<script src="' + "../" * depth + 'header.js"></script>'
+                  f.write_text(text.replace("</body>", script + "\n</body>", 1), "utf-8")
 
           def generate_tasks_html(cdir, cb):
               """Generate tasks.html from tasks.md if the latter exists."""
@@ -163,7 +163,7 @@ jobs:
                   "<style>" + CSS + "</style>",
                   "</head>",
                   "<body>",
-                  HEADER_SCRIPT,
+                  '<script src="' + "../" * (len((cb / "tasks.html").relative_to(BUILD).parts) - 1) + 'header.js"></script>',
                   '<div class="wrap">',
                   body,
                   "</div>",

--- a/.github/workflows/spec-pages.yml
+++ b/.github/workflows/spec-pages.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - "docs/changes/**"
       - "docs/shell.html"
+      - "docs/header.js"
   workflow_dispatch:
 
 # GitHub Pages on a private repo is only accessible to repository collaborators.
@@ -36,13 +37,14 @@ jobs:
       - name: Build site
         run: |
           python3 - <<'PYEOF'
-          import os, json, re, shutil, pathlib
+          import os, json, re, shutil, pathlib, html
           from datetime import datetime, timezone
 
           BUILD   = pathlib.Path(".pages-build")
           CHANGES = pathlib.Path("docs/changes")
           ARCHIVE = CHANGES / "archive"
           SHELL   = pathlib.Path("docs/shell.html")
+          HEADER  = pathlib.Path("docs/header.js")
           repo    = os.environ.get("GH_REPO", "")
 
           BUILD.mkdir(exist_ok=True)
@@ -51,10 +53,103 @@ jobs:
 
           if SHELL.exists():
               shutil.copy(SHELL, BUILD / "shell.html")
+          if HEADER.exists():
+              shutil.copy(HEADER, BUILD / "header.js")
 
           def esc(s):
               if s is None: return ""
               return str(s).replace("&","&amp;").replace("<","&lt;").replace(">","&gt;").replace('"',"&quot;")
+
+          HEADER_SCRIPT = '<script src="/header.js"></script>'
+
+          def inject_header(cb):
+              """Inject /header.js into every artifact HTML except mockup.html."""
+              for f in cb.rglob("*.html"):
+                  if f.name == "mockup.html": continue
+                  text = f.read_text("utf-8")
+                  if "</body>" in text and HEADER_SCRIPT not in text:
+                      f.write_text(text.replace("</body>", HEADER_SCRIPT + "\n</body>", 1), "utf-8")
+
+          def generate_tasks_html(cdir, cb):
+              """Generate tasks.html from tasks.md if the latter exists."""
+              tf = cdir / "tasks.md"
+              if not tf.exists(): return
+              md = tf.read_text("utf-8")
+
+              def esc_h(s): return html.escape(str(s))
+
+              lines = md.replace("\r", "").split("\n")
+              body  = ""
+              i = 0
+              while i < len(lines):
+                  l = lines[i]
+                  hm = re.match(r"^(#{1,4})\s+(.*)", l)
+                  if hm:
+                      lvl  = len(hm.group(1))
+                      body += f"<h{lvl}>{esc_h(hm.group(2))}</h{lvl}>"
+                      i += 1; continue
+                  tm = re.match(r"^\s*[-*]\s+\[([ xX])\]\s+(.*)", l)
+                  if tm:
+                      done = tm.group(1).lower() == "x"
+                      text = esc_h(tm.group(2))
+                      cls  = "task done" if done else "task"
+                      box  = "✓" if done else "☐"
+                      body += f'<li class="{cls}"><span class="box">{box}</span> {text}</li>'
+                      i += 1; continue
+                  bm = re.match(r"^>\s?(.*)", l)
+                  if bm:
+                      buf = []
+                      while i < len(lines) and lines[i].startswith(">"):
+                          buf.append(re.sub(r"^>\s?", "", lines[i]))
+                          i += 1
+                      text = "\n".join(buf)
+                      if text.upper().startswith("BLOCKED"):
+                          body += f'<details class="blocked" open><summary>{esc_h(text.split(chr(10))[0])}</summary></details>'
+                      else:
+                          body += f"<blockquote>{esc_h(text)}</blockquote>"
+                      continue
+                  if l.strip():
+                      body += f"<p>{esc_h(l)}</p>"
+                  i += 1
+
+              tasks_html = f"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Tasks</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400;12..96,600;12..96,700&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+:root{{--bg:#0c0c10;--surface:#14141c;--border:#22222e;--text:#e2e2f0;--muted:#7878a0;--accent:#818cf8;--ok:#34d399;--bad:#f87171}}
+@media(prefers-color-scheme:light){{:root{{--bg:#f4f4f9;--surface:#ffffff;--border:#dddde8;--text:#1a1a2e;--muted:#6868a0;--accent:#6366f1;--ok:#059669;--bad:#dc2626}}}}
+[data-theme=dark]{{--bg:#0c0c10;--surface:#14141c;--border:#22222e;--text:#e2e2f0;--muted:#7878a0;--accent:#818cf8;--ok:#34d399;--bad:#f87171}}
+[data-theme=light]{{--bg:#f4f4f9;--surface:#ffffff;--border:#dddde8;--text:#1a1a2e;--muted:#6868a0;--accent:#6366f1;--ok:#059669;--bad:#dc2626}}
+*{{box-sizing:border-box}}
+body{{margin:0;font:15px/1.7 'Bricolage Grotesque',system-ui,sans-serif;background:var(--bg);color:var(--text);-webkit-font-smoothing:antialiased}}
+.wrap{{max-width:820px;margin:0 auto;padding:28px 20px 72px}}
+h2{{font-size:17px;font-weight:700;margin:28px 0 10px;padding-bottom:6px;border-bottom:1px solid var(--border)}}
+h3,h4{{font-size:14px;font-weight:600;margin:20px 0 6px;color:var(--muted)}}
+ul{{padding:0;list-style:none;margin:0}}
+li.task{{display:flex;align-items:baseline;gap:9px;padding:5px 0;font-size:14px;line-height:1.5}}
+li.task .box{{font-weight:700;font-family:'IBM Plex Mono',monospace;flex-shrink:0;min-width:1.2em;color:var(--muted)}}
+li.task.done .box{{color:var(--ok)}}
+li.task.done{{color:var(--muted);text-decoration:line-through;text-decoration-color:var(--border)}}
+details.blocked{{border:1px solid var(--bad);background:color-mix(in srgb,var(--bad) 8%,transparent);border-radius:8px;padding:10px 14px;margin:12px 0}}
+details.blocked summary{{color:var(--bad);font-weight:600;cursor:pointer;font-size:13px;font-family:'IBM Plex Mono',monospace}}
+blockquote{{border-left:3px solid var(--border);margin:10px 0;padding:3px 14px;color:var(--muted);font-size:13px}}
+p{{font-size:14px;color:var(--muted)}}
+</style>
+</head>
+<body>
+{HEADER_SCRIPT}
+<div class="wrap">
+{body}
+</div>
+</body>
+</html>"""
+              (cb / "tasks.html").write_text(tasks_html, "utf-8")
 
           def copy_artifacts(cdir, cb):
               cb.mkdir(parents=True, exist_ok=True)
@@ -65,6 +160,8 @@ jobs:
               specs_src = cdir / "specs"
               if specs_src.exists():
                   shutil.copytree(specs_src, cb / "specs", dirs_exist_ok=True)
+              generate_tasks_html(cdir, cb)
+              inject_header(cb)
 
           def make_manifest(cdir, name, arch_date=None):
               meta = {}

--- a/docs/header.js
+++ b/docs/header.js
@@ -1,15 +1,14 @@
 (function () {
-  // Derive change context from URL path.
-  // Handles: /changes/<name>/<artifact>.html
-  //          /changes/archive/<date-name>/<artifact>.html
-  //          /changes/<name>/specs/<cap>/spec.html  (inSpecs = true)
   var path = location.pathname;
-  var m = path.match(/\/changes\/((?:archive\/)?)([^/]+)\//);
+
+  // Capture everything before /changes/ as siteRoot (e.g. '/volleybro' or '').
+  var m = path.match(/^(.*?)\/changes\/((?:archive\/)?)([^/]+)\//);
   if (!m) return;
 
-  var prefix      = m[1];                            // "" | "archive/"
-  var dirName     = m[2];
-  var changePath  = '/changes/' + prefix + dirName + '/';
+  var siteRoot    = m[1];
+  var prefix      = m[2];
+  var dirName     = m[3];
+  var changePath  = siteRoot + '/changes/' + prefix + dirName + '/';
   var changeParam = prefix + dirName;
   var displayName = dirName.replace(/^\d{4}-\d{2}-\d{2}-/, '');
 
@@ -18,7 +17,6 @@
   var inSpecs     = path.indexOf(changePath + 'specs/') === 0;
   if (inSpecs) currentFile = '__specs__';
 
-  // ── Theme ──────────────────────────────────────────────────────────────────
   var DARK  = '--bg:#0c0c10;--surface:#14141c;--border:#22222e;--text:#e2e2f0;--muted:#7878a0;--accent:#818cf8;--ok:#34d399;--warn:#fbbf24;--bad:#f87171;--fg:#e2e2f0;--card:#14141c;--line:#22222e;--mut:#7878a0';
   var LIGHT = '--bg:#f4f4f9;--surface:#ffffff;--border:#dddde8;--text:#1a1a2e;--muted:#6868a0;--accent:#6366f1;--ok:#059669;--warn:#d97706;--bad:#dc2626;--fg:#1a1a2e;--card:#ffffff;--line:#dddde8;--mut:#6868a0';
 
@@ -26,7 +24,6 @@
 
   function applyTheme(t) {
     document.documentElement.dataset.theme = t;
-    // Use setProperty so inline-style specificity beats any stylesheet rule.
     var vars = t === 'dark' ? DARK : LIGHT;
     vars.split(';').forEach(function (v) {
       var i = v.indexOf(':');
@@ -36,13 +33,11 @@
     if (btn) btn.textContent = t === 'dark' ? '☀' : '☾';
   }
 
-  // Apply vars immediately (synchronous, before DOM ready) to avoid flash.
   applyTheme(getTheme());
 
-  // ── DOM init ───────────────────────────────────────────────────────────────
   function esc(s) {
     return String(s).replace(/[&<>"]/g, function (c) {
-      return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c];
+      return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c];
     });
   }
 
@@ -61,7 +56,7 @@
     if (specs.length === 1)
       tabs += tab('__specs__', 'Spec', changePath + 'specs/' + specs[0].name + '/spec.html');
     else if (specs.length > 1)
-      tabs += tab('__specs__', 'Specs (' + specs.length + ')', '/shell.html?change=' + encodeURIComponent(changeParam) + '&tab=specs');
+      tabs += tab('__specs__', 'Specs (' + specs.length + ')', siteRoot + '/shell.html?change=' + encodeURIComponent(changeParam) + '#specs');
     if (!manifest || (a.design && (a.design.html || a.design.md)))
       tabs += tab('design', 'Design', changePath + 'design.html');
     tabs += tab('tasks', 'Tasks', changePath + 'tasks.html');
@@ -70,9 +65,9 @@
 
     var t = getTheme();
     return '<div id="__sh-in">' +
-      '<a class="__sh-a" href="/index.html">← All</a>' +
+      '<a class="__sh-a" href="' + esc(siteRoot + '/index.html') + '">← All</a>' +
       '<span class="__sh-sep" aria-hidden="true"></span>' +
-      '<a class="__sh-a" id="__sh-name" href="/shell.html?change=' + esc(changeParam) + '">' + esc(displayName) + '</a>' +
+      '<a class="__sh-a" id="__sh-name" href="' + esc(siteRoot + '/shell.html?change=' + changeParam) + '">' + esc(displayName) + '</a>' +
       '<nav id="__sh-tabs" aria-label="Artifacts">' + tabs + '</nav>' +
       '<button id="__sh-theme" title="Toggle theme" aria-label="Toggle theme">' + (t === 'dark' ? '☀' : '☾') + '</button>' +
       '</div>';
@@ -128,6 +123,7 @@
         if (!manifest) return;
         bar.innerHTML = buildBar(manifest);
         wireTheme();
+        applyTheme(getTheme());
       })
       .catch(function () {});
   }
@@ -135,4 +131,3 @@
   if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init);
   else init();
 })();
-

--- a/docs/header.js
+++ b/docs/header.js
@@ -26,14 +26,17 @@
 
   function applyTheme(t) {
     document.documentElement.dataset.theme = t;
-    var s = document.getElementById('__sh-vars');
-    if (!s) { s = document.createElement('style'); s.id = '__sh-vars'; (document.head || document.documentElement).appendChild(s); }
-    s.textContent = ':root{' + (t === 'dark' ? DARK : LIGHT) + '}';
+    // Use setProperty so inline-style specificity beats any stylesheet rule.
+    var vars = t === 'dark' ? DARK : LIGHT;
+    vars.split(';').forEach(function (v) {
+      var i = v.indexOf(':');
+      if (i > 0) document.documentElement.style.setProperty(v.slice(0, i).trim(), v.slice(i + 1).trim());
+    });
     var btn = document.getElementById('__sh-theme');
     if (btn) btn.textContent = t === 'dark' ? '☀' : '☾';
   }
 
-  // Apply vars immediately to avoid theme flash before DOM is ready.
+  // Apply vars immediately (synchronous, before DOM ready) to avoid flash.
   applyTheme(getTheme());
 
   // ── DOM init ───────────────────────────────────────────────────────────────

--- a/docs/header.js
+++ b/docs/header.js
@@ -132,3 +132,4 @@
   if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init);
   else init();
 })();
+

--- a/docs/header.js
+++ b/docs/header.js
@@ -1,0 +1,134 @@
+(function () {
+  // Derive change context from URL path.
+  // Handles: /changes/<name>/<artifact>.html
+  //          /changes/archive/<date-name>/<artifact>.html
+  //          /changes/<name>/specs/<cap>/spec.html  (inSpecs = true)
+  var path = location.pathname;
+  var m = path.match(/\/changes\/((?:archive\/)?)([^/]+)\//);
+  if (!m) return;
+
+  var prefix      = m[1];                            // "" | "archive/"
+  var dirName     = m[2];
+  var changePath  = '/changes/' + prefix + dirName + '/';
+  var changeParam = prefix + dirName;
+  var displayName = dirName.replace(/^\d{4}-\d{2}-\d{2}-/, '');
+
+  var segments    = path.split('/');
+  var currentFile = segments[segments.length - 1].replace(/\.html$/, '');
+  var inSpecs     = path.indexOf(changePath + 'specs/') === 0;
+  if (inSpecs) currentFile = '__specs__';
+
+  // ── Theme ──────────────────────────────────────────────────────────────────
+  var DARK  = '--bg:#0c0c10;--surface:#14141c;--border:#22222e;--text:#e2e2f0;--muted:#7878a0;--accent:#818cf8;--ok:#34d399;--warn:#fbbf24;--bad:#f87171;--fg:#e2e2f0;--card:#14141c;--line:#22222e;--mut:#7878a0';
+  var LIGHT = '--bg:#f4f4f9;--surface:#ffffff;--border:#dddde8;--text:#1a1a2e;--muted:#6868a0;--accent:#6366f1;--ok:#059669;--warn:#d97706;--bad:#dc2626;--fg:#1a1a2e;--card:#ffffff;--line:#dddde8;--mut:#6868a0';
+
+  function getTheme() { return localStorage.getItem('theme') || (matchMedia('(prefers-color-scheme:dark)').matches ? 'dark' : 'light'); }
+
+  function applyTheme(t) {
+    document.documentElement.dataset.theme = t;
+    var s = document.getElementById('__sh-vars');
+    if (!s) { s = document.createElement('style'); s.id = '__sh-vars'; (document.head || document.documentElement).appendChild(s); }
+    s.textContent = ':root{' + (t === 'dark' ? DARK : LIGHT) + '}';
+    var btn = document.getElementById('__sh-theme');
+    if (btn) btn.textContent = t === 'dark' ? '☀' : '☾';
+  }
+
+  // Apply vars immediately to avoid theme flash before DOM is ready.
+  applyTheme(getTheme());
+
+  // ── DOM init ───────────────────────────────────────────────────────────────
+  function esc(s) {
+    return String(s).replace(/[&<>"]/g, function (c) {
+      return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c];
+    });
+  }
+
+  function buildBar(manifest) {
+    var a     = manifest && manifest.artifacts || {};
+    var specs = manifest && manifest.specs || [];
+
+    function tab(id, label, href) {
+      var cur = id === currentFile ? ' aria-current="page"' : '';
+      return '<a class="__sh-tab"' + cur + ' href="' + esc(href) + '">' + esc(label) + '</a>';
+    }
+
+    var tabs = '';
+    if (!manifest || (a.proposal && (a.proposal.html || a.proposal.md)))
+      tabs += tab('proposal', 'Proposal', changePath + 'proposal.html');
+    if (specs.length === 1)
+      tabs += tab('__specs__', 'Spec', changePath + 'specs/' + specs[0].name + '/spec.html');
+    else if (specs.length > 1)
+      tabs += tab('__specs__', 'Specs (' + specs.length + ')', '/shell.html?change=' + encodeURIComponent(changeParam) + '&tab=specs');
+    if (!manifest || (a.design && (a.design.html || a.design.md)))
+      tabs += tab('design', 'Design', changePath + 'design.html');
+    tabs += tab('tasks', 'Tasks', changePath + 'tasks.html');
+    if (manifest && a.review && (a.review.html || a.review.md))
+      tabs += tab('review', 'Review', changePath + 'review.html');
+
+    var t = getTheme();
+    return '<div id="__sh-in">' +
+      '<a class="__sh-a" href="/index.html">← All</a>' +
+      '<span class="__sh-sep" aria-hidden="true"></span>' +
+      '<a class="__sh-a" id="__sh-name" href="/shell.html?change=' + esc(changeParam) + '">' + esc(displayName) + '</a>' +
+      '<nav id="__sh-tabs" aria-label="Artifacts">' + tabs + '</nav>' +
+      '<button id="__sh-theme" title="Toggle theme" aria-label="Toggle theme">' + (t === 'dark' ? '☀' : '☾') + '</button>' +
+      '</div>';
+  }
+
+  function wireTheme() {
+    var btn = document.getElementById('__sh-theme');
+    if (btn) btn.onclick = function () {
+      var n = getTheme() === 'dark' ? 'light' : 'dark';
+      localStorage.setItem('theme', n);
+      applyTheme(n);
+    };
+  }
+
+  function init() {
+    var css = document.createElement('style');
+    css.textContent =
+      '#__sh{position:sticky;top:0;z-index:100;font-family:"Bricolage Grotesque",system-ui,sans-serif;' +
+        'background:color-mix(in srgb,var(--bg,#0c0c10) 90%,transparent);backdrop-filter:blur(14px);' +
+        'border-bottom:1px solid var(--border,#22222e)}' +
+      '#__sh-in{display:flex;align-items:center;gap:4px;max-width:1140px;margin:0 auto;padding:0 16px;min-height:48px}' +
+      '.__sh-a{appearance:none;background:none;border:0;cursor:pointer;' +
+        'font:14px/1 "Bricolage Grotesque",system-ui,sans-serif;color:var(--muted,#7878a0);' +
+        'padding:5px 9px;border-radius:6px;text-decoration:none;white-space:nowrap}' +
+      '.__sh-a:hover{color:var(--text,#e2e2f0);background:var(--surface,#14141c)}' +
+      '#__sh-name{font-family:"IBM Plex Mono",monospace;font-size:12px;font-weight:500;' +
+        'letter-spacing:-.2px;color:var(--text,#e2e2f0)}' +
+      '.__sh-sep{width:1px;height:14px;background:var(--border,#22222e);margin:0 2px;flex-shrink:0}' +
+      '#__sh-tabs{display:flex;align-items:flex-end;height:48px;margin-left:auto;overflow-x:auto}' +
+      '.__sh-tab{appearance:none;background:none;border:0;border-bottom:2px solid transparent;' +
+        'color:var(--muted,#7878a0);padding:6px 11px;' +
+        'font:13px/1 "Bricolage Grotesque",system-ui,sans-serif;' +
+        'cursor:pointer;height:100%;white-space:nowrap;text-decoration:none;' +
+        'display:inline-flex;align-items:center;transition:color .12s,border-color .12s}' +
+      '.__sh-tab[aria-current]{color:var(--accent,#818cf8);border-bottom-color:var(--accent,#818cf8)}' +
+      '.__sh-tab:hover{color:var(--text,#e2e2f0)}' +
+      '#__sh-theme{appearance:none;background:var(--surface,#14141c);border:1px solid var(--border,#22222e);' +
+        'cursor:pointer;font-size:13px;padding:3px 10px;border-radius:20px;color:var(--muted,#7878a0);' +
+        'margin-left:8px;flex-shrink:0;line-height:1.6;transition:border-color .12s}' +
+      '#__sh-theme:hover{border-color:var(--accent,#818cf8);color:var(--text,#e2e2f0)}';
+    document.head.appendChild(css);
+
+    var bar = document.createElement('header');
+    bar.id = '__sh';
+    document.body.insertBefore(bar, document.body.firstChild);
+
+    bar.innerHTML = buildBar(null);
+    wireTheme();
+
+    fetch(changePath + 'manifest.json')
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (manifest) {
+        if (!manifest) return;
+        bar.innerHTML = buildBar(manifest);
+        wireTheme();
+      })
+      .catch(function () {});
+  }
+
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init);
+  else init();
+})();

--- a/docs/shell.html
+++ b/docs/shell.html
@@ -130,6 +130,11 @@ function injectIframe(f, t) {
     let s = doc.getElementById('__sh');
     if (!s) { s = doc.createElement('style'); s.id = '__sh'; (doc.head || doc.documentElement).appendChild(s); }
     s.textContent = ':root{' + VARS[t] + '}';
+    // recurse into nested iframes (e.g. mockup.html inside design.html)
+    doc.querySelectorAll('iframe').forEach(n => {
+      injectIframe(n, t);
+      n.addEventListener('load', () => injectIframe(n, t));
+    });
   } catch(e) {}
 }
 function applyTheme(t) {

--- a/docs/shell.html
+++ b/docs/shell.html
@@ -8,54 +8,24 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,300;12..96,400;12..96,500;12..96,600;12..96,700&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet">
 <style>
-:root {
-  --bg:#0c0c10;--surface:#14141c;--border:#22222e;
-  --text:#e2e2f0;--muted:#7878a0;--accent:#818cf8;
-  --ok:#34d399;--warn:#fbbf24;--bad:#f87171;
-  /* legacy compat for artifact HTML files */
-  --fg:var(--text);--card:var(--surface);--line:var(--border);--mut:var(--muted);
-}
-@media(prefers-color-scheme:light){
-  :root{--bg:#f4f4f9;--surface:#ffffff;--border:#dddde8;
-    --text:#1a1a2e;--muted:#6868a0;--accent:#6366f1;
-    --ok:#059669;--warn:#d97706;--bad:#dc2626}
-}
+:root{--bg:#0c0c10;--surface:#14141c;--border:#22222e;--text:#e2e2f0;--muted:#7878a0;--accent:#818cf8;--ok:#34d399;--warn:#fbbf24;--bad:#f87171}
+@media(prefers-color-scheme:light){:root{--bg:#f4f4f9;--surface:#ffffff;--border:#dddde8;--text:#1a1a2e;--muted:#6868a0;--accent:#6366f1;--ok:#059669;--warn:#d97706;--bad:#dc2626}}
 [data-theme=dark]{--bg:#0c0c10;--surface:#14141c;--border:#22222e;--text:#e2e2f0;--muted:#7878a0;--accent:#818cf8;--ok:#34d399;--warn:#fbbf24;--bad:#f87171}
 [data-theme=light]{--bg:#f4f4f9;--surface:#ffffff;--border:#dddde8;--text:#1a1a2e;--muted:#6868a0;--accent:#6366f1;--ok:#059669;--warn:#d97706;--bad:#dc2626}
-
 *{box-sizing:border-box}
 body{margin:0;font:15px/1.65 'Bricolage Grotesque',system-ui,sans-serif;background:var(--bg);color:var(--text);-webkit-font-smoothing:antialiased}
-
-/* ── Header ──────────────────────────────────────────────────────────────── */
 .bar{position:sticky;top:0;z-index:10;background:color-mix(in srgb,var(--bg) 90%,transparent);backdrop-filter:blur(14px);border-bottom:1px solid var(--border)}
 .bar-in{display:flex;align-items:center;gap:6px;max-width:1140px;margin:0 auto;padding:0 18px;min-height:50px}
-.nav-grp{display:flex;align-items:center;gap:2px;flex-shrink:0}
-.btn{appearance:none;background:none;border:0;cursor:pointer;font:'Bricolage Grotesque',system-ui,sans-serif;font-size:14px;
-  color:var(--muted);padding:5px 9px;border-radius:6px;text-decoration:none;white-space:nowrap;line-height:1.4}
+.btn{appearance:none;background:none;border:0;cursor:pointer;font-size:14px;font-family:'Bricolage Grotesque',system-ui,sans-serif;color:var(--muted);padding:5px 9px;border-radius:6px;text-decoration:none;white-space:nowrap;line-height:1.4}
 .btn:hover{color:var(--text);background:var(--surface)}
 .btn:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
-.btn.home-btn{font-weight:500;color:var(--text)}
-.mono{font-family:'IBM Plex Mono',monospace;font-size:12px;font-weight:500;letter-spacing:-.2px}
+.name{font-family:'IBM Plex Mono',monospace;font-size:12px;font-weight:500;letter-spacing:-.2px;color:var(--text)}
 .sep{width:1px;height:14px;background:var(--border);margin:0 2px;flex-shrink:0}
-.tabs{display:flex;align-items:flex-end;gap:0;margin-left:auto;height:50px;overflow-x:auto}
-.tab{appearance:none;background:none;border:0;border-bottom:2px solid transparent;
-  color:var(--muted);padding:6px 12px;font:14px/1 'Bricolage Grotesque',system-ui,sans-serif;
-  cursor:pointer;height:100%;white-space:nowrap;transition:color .12s,border-color .12s}
-.tab[aria-selected=true]{color:var(--accent);border-bottom-color:var(--accent)}
-.tab:hover{color:var(--text)}
-.tab:focus-visible{outline:2px solid var(--accent);outline-offset:-2px}
-.theme-pill{appearance:none;background:var(--surface);border:1px solid var(--border);
-  cursor:pointer;font-size:13px;padding:3px 10px;border-radius:20px;color:var(--muted);
-  margin-left:8px;flex-shrink:0;transition:border-color .12s,color .12s;line-height:1.6}
+.theme-pill{appearance:none;background:var(--surface);border:1px solid var(--border);cursor:pointer;font-size:13px;padding:3px 10px;border-radius:20px;color:var(--muted);margin-left:auto;flex-shrink:0;transition:border-color .12s;line-height:1.6}
 .theme-pill:hover{border-color:var(--accent);color:var(--text)}
-
-/* ── Content ─────────────────────────────────────────────────────────────── */
 main{min-height:60vh}
-iframe.auto{width:100%;border:0;display:block}
 .wrap{max-width:900px;margin:0 auto;padding:28px 20px 72px}
 .placeholder{color:var(--muted);border:1px dashed var(--border);border-radius:10px;padding:36px;text-align:center;font-size:14px}
-
-/* ── Overview ────────────────────────────────────────────────────────────── */
 .ov-name{font-size:26px;font-weight:700;margin:0 0 8px;letter-spacing:-.4px;line-height:1.2}
 .ov-sum{color:var(--muted);font-size:14.5px;margin:0 0 22px;line-height:1.55;max-width:620px}
 .ov-prog{display:flex;align-items:center;gap:14px;margin-bottom:28px}
@@ -63,10 +33,7 @@ iframe.auto{width:100%;border:0;display:block}
 .prog-fill{height:100%;background:var(--accent);border-radius:2px;transition:width .4s ease}
 .prog-label{font-family:'IBM Plex Mono',monospace;font-size:12px;color:var(--muted);white-space:nowrap}
 .ov-grid{display:flex;flex-direction:column;gap:6px}
-.ov-btn{text-align:left;background:none;border:1px solid var(--border);border-radius:9px;
-  padding:13px 16px;cursor:pointer;font:'Bricolage Grotesque',system-ui,sans-serif;font-size:14px;
-  color:var(--text);display:flex;align-items:center;gap:12px;
-  transition:border-color .12s,background .12s;width:100%}
+.ov-btn{text-align:left;background:none;border:1px solid var(--border);border-radius:9px;padding:13px 16px;font-size:14px;font-family:'Bricolage Grotesque',system-ui,sans-serif;color:var(--text);display:flex;align-items:center;gap:12px;text-decoration:none;transition:border-color .12s,background .12s;width:100%}
 .ov-btn:hover{border-color:var(--accent);background:color-mix(in srgb,var(--accent) 5%,transparent)}
 .ov-btn:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
 .ov-info{flex:1;display:flex;flex-direction:column;gap:1px}
@@ -75,260 +42,85 @@ iframe.auto{width:100%;border:0;display:block}
 .ov-stat{font-family:'IBM Plex Mono',monospace;font-size:11px;color:var(--muted);white-space:nowrap;flex-shrink:0}
 .ov-arr{color:var(--border);font-size:16px;transition:color .12s,transform .12s;flex-shrink:0}
 .ov-btn:hover .ov-arr{color:var(--accent);transform:translateX(2px)}
-
-/* ── Markdown ────────────────────────────────────────────────────────────── */
-.md{font-size:15px;line-height:1.7}
-.md h1,.md h2,.md h3{font-family:'Bricolage Grotesque',system-ui,sans-serif;line-height:1.25;font-weight:700}
-.md h2{border-bottom:1px solid var(--border);padding-bottom:6px;margin-top:32px}
-.md code{background:var(--surface);border:1px solid var(--border);border-radius:5px;
-  padding:1px 6px;font:.88em/1 'IBM Plex Mono',monospace}
-.md pre{background:var(--surface);border:1px solid var(--border);border-radius:9px;
-  padding:14px 16px;overflow:auto;margin:12px 0}
-.md pre code{border:0;padding:0;background:none}
-.md a{color:var(--accent);text-underline-offset:3px}
-.md table{border-collapse:collapse;width:100%;margin:14px 0;font-size:14px}
-.md th,.md td{border:1px solid var(--border);padding:7px 11px;text-align:left}
-.md th{background:var(--surface);font-weight:600}
-.md blockquote{border-left:3px solid var(--border);margin:12px 0;padding:3px 16px;color:var(--muted)}
-.md li.task{list-style:none}
-.md li.task>.box{display:inline-block;width:1.3em;margin-left:-1.3em;font-weight:700}
-.md li.task.done>.box{color:var(--ok)}
-.md .p{display:inline-block;font-size:11px;border:1px solid var(--accent);color:var(--accent);
-  border-radius:4px;padding:0 4px;margin:0 3px;font-family:'IBM Plex Mono',monospace}
-details.blocked{border:1px solid var(--bad);background:color-mix(in srgb,var(--bad) 10%,transparent);
-  border-radius:9px;padding:9px 14px;margin:12px 0}
-details.blocked summary{color:var(--bad);font-weight:600;cursor:pointer}
-details.blocked summary::before{content:"\26A0\FE0F  "}
+.ov-sec{font-family:'IBM Plex Mono',monospace;font-size:11px;font-weight:600;letter-spacing:.08em;text-transform:uppercase;color:var(--muted);margin:24px 0 8px}
 </style>
 </head>
 <body>
 <header class="bar">
   <div class="bar-in">
-    <div class="nav-grp">
-      <a class="btn" href="index.html">← All</a>
-      <span class="sep" aria-hidden="true"></span>
-      <button class="btn home-btn" id="homeBtn"><span class="mono" id="hname">…</span></button>
-    </div>
-    <nav class="tabs" role="tablist" id="tabs"></nav>
+    <a class="btn" href="index.html">← All</a>
+    <span class="sep" aria-hidden="true"></span>
+    <span class="btn name" id="hname">…</span>
     <button class="theme-pill" id="themeBtn" title="Toggle theme" aria-label="Toggle theme"></button>
   </div>
 </header>
-<main id="panel" role="tabpanel" tabindex="0" aria-live="polite"><div class="wrap">Loading…</div></main>
+<main>
+  <div class="wrap" id="content"><p class="placeholder">Loading…</p></div>
+</main>
 
 <script>
-// ── Theme (with iframe injection) ────────────────────────────────────────────
-const VARS = {
-  dark:  '--bg:#0c0c10;--surface:#14141c;--border:#22222e;--text:#e2e2f0;--muted:#7878a0;--accent:#818cf8;--ok:#34d399;--warn:#fbbf24;--bad:#f87171;--fg:#e2e2f0;--card:#14141c;--line:#22222e;--mut:#7878a0',
-  light: '--bg:#f4f4f9;--surface:#ffffff;--border:#dddde8;--text:#1a1a2e;--muted:#6868a0;--accent:#6366f1;--ok:#059669;--warn:#d97706;--bad:#dc2626;--fg:#1a1a2e;--card:#ffffff;--line:#dddde8;--mut:#6868a0'
-};
 const themeBtn = document.getElementById('themeBtn');
-const sys = () => window.matchMedia('(prefers-color-scheme:dark)').matches ? 'dark' : 'light';
+const sys = () => matchMedia('(prefers-color-scheme:dark)').matches ? 'dark' : 'light';
 function getTheme() { return document.documentElement.dataset.theme || sys(); }
-function injectIframe(f, t) {
-  try {
-    const doc = f.contentWindow.document;
-    let s = doc.getElementById('__sh');
-    if (!s) { s = doc.createElement('style'); s.id = '__sh'; (doc.head || doc.documentElement).appendChild(s); }
-    s.textContent = ':root{' + VARS[t] + '}';
-    // recurse into nested iframes (e.g. mockup.html inside design.html)
-    doc.querySelectorAll('iframe').forEach(n => {
-      injectIframe(n, t);
-      n.addEventListener('load', () => injectIframe(n, t));
-    });
-  } catch(e) {}
-}
-function applyTheme(t) {
-  document.documentElement.dataset.theme = t;
-  themeBtn.textContent = t === 'dark' ? '☀' : '☾';
-  document.querySelectorAll('iframe.auto').forEach(f => injectIframe(f, t));
-}
+function applyTheme(t) { document.documentElement.dataset.theme = t; themeBtn.textContent = t === 'dark' ? '☀' : '☾'; }
 themeBtn.onclick = () => { const n = getTheme() === 'dark' ? 'light' : 'dark'; localStorage.setItem('theme', n); applyTheme(n); };
 applyTheme(localStorage.getItem('theme') || sys());
 
-// ── Core ─────────────────────────────────────────────────────────────────────
-const TABS   = ['proposal','specs','design','tasks','review'];
-const LABELS = {proposal:'Proposal',specs:'Specs',design:'Design',tasks:'Tasks',review:'Review'};
-const HINTS  = {proposal:'Why · what · impact',specs:'GIVEN/WHEN/THEN',design:'Decisions & contract',tasks:'Live checklist',review:'Post-apply verdict'};
 const params = new URLSearchParams(location.search);
 const change = params.get('change');
 const base   = `changes/${change}`;
-const panel  = document.getElementById('panel');
-const homeBtn = document.getElementById('homeBtn');
-const tabEl  = {};
+const esc = s => String(s).replace(/[&<>"]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
 
-const esc = s => s.replace(/[&<>"]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
-
-// ── Markdown renderer ─────────────────────────────────────────────────────────
-function inline(s) {
-  return esc(s)
-    .replace(/`([^`]+)`/g, '<code>$1</code>')
-    .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
-    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" target="_blank" rel="noopener">$1</a>');
+function btn(href, label, hint, stat) {
+  return `<a class="ov-btn" href="${esc(href)}">
+    <div class="ov-info"><span class="ov-label">${esc(label)}</span><span class="ov-hint">${esc(hint)}</span></div>
+    <span class="ov-stat">${stat}</span><span class="ov-arr">›</span>
+  </a>`;
 }
-function renderMd(src) {
-  const lines = src.replace(/\r/g,'').split('\n');
-  let html = '', i = 0;
-  const close = [];
-  const flush = () => { while (close.length) html += close.pop(); };
-  while (i < lines.length) {
-    let l = lines[i];
-    if (/^```/.test(l)) {
-      flush(); i++; let buf = [];
-      while (i < lines.length && !/^```/.test(lines[i])) buf.push(lines[i++]);
-      i++; html += `<pre><code>${esc(buf.join('\n'))}</code></pre>`; continue;
-    }
-    const h = l.match(/^(#{1,4})\s+(.*)/);
-    if (h) { flush(); html += `<h${h[1].length}>${inline(h[2])}</h${h[1].length}>`; i++; continue; }
-    if (/^\s*[-*]\s+\[[ xX]\]/.test(l)) {
-      if (!close.length) { html += '<ul>'; close.push('</ul>'); }
-      const m = l.match(/^\s*[-*]\s+\[([ xX])\]\s+(.*)/);
-      const done = m[1] !== ' ';
-      html += `<li class="task ${done?'done':''}"><span class="box">${done?'✓':'☐'}</span> ${inline(m[2]).replace(/\s\[P\]/g,' <span class="p">P</span>')}</li>`;
-      i++; continue;
-    }
-    if (/^\s*[-*]\s+/.test(l)) {
-      if (!close.length) { html += '<ul>'; close.push('</ul>'); }
-      html += `<li>${inline(l.replace(/^\s*[-*]\s+/,''))}</li>`; i++; continue;
-    }
-    if (/^>\s?/.test(l)) {
-      flush(); let buf = [];
-      while (i < lines.length && /^>\s?/.test(lines[i])) buf.push(lines[i++].replace(/^>\s?/,''));
-      const text = buf.join('\n');
-      const bm = text.match(/^BLOCKED[^\n]*/);
-      if (bm) html += `<details class="blocked" open><summary>${inline(bm[0])}</summary>${inline(text.slice(bm[0].length)).replace(/\n/g,'<br>')}</details>`;
-      else html += `<blockquote>${inline(text).replace(/\n/g,'<br>')}</blockquote>`;
-      continue;
-    }
-    if (/^\s*\|.*\|/.test(l) && /^\s*\|[\s:|-]+\|/.test(lines[i+1]||'')) {
-      flush();
-      const row = s => s.trim().replace(/^\||\|$/g,'').split('|').map(c => c.trim());
-      const head = row(l); i += 2; let body = '';
-      while (i < lines.length && /^\s*\|.*\|/.test(lines[i]))
-        body += '<tr>' + row(lines[i++]).map(c => `<td>${inline(c)}</td>`).join('') + '</tr>';
-      html += `<table><thead><tr>${head.map(c=>`<th>${inline(c)}</th>`).join('')}</tr></thead><tbody>${body}</tbody></table>`;
-      continue;
-    }
-    if (/^(---|\*\*\*)\s*$/.test(l)) { flush(); html += '<hr>'; i++; continue; }
-    if (l.trim() === '') { flush(); i++; continue; }
-    flush(); html += `<p>${inline(l)}</p>`; i++;
-  }
-  flush();
-  return `<div class="md">${html}</div>`;
-}
-
-// ── Render helpers ────────────────────────────────────────────────────────────
-async function fetchText(url) { const r = await fetch(url); return r.ok ? r.text() : null; }
-const mkIframe = (src, title) => `<iframe class="auto" title="${esc(title)}" src="${src}"></iframe>`;
-const wrap = h => `<div class="wrap">${h}</div>`;
-const placeholder = t => wrap(`<div class="placeholder">${esc(t)}</div>`);
-const avail = x => x && x.html ? 'HTML authored' : x && x.md ? 'from .md' : 'not yet';
-
-let manifest, active;
 
 async function load() {
-  if (!change) { panel.innerHTML = wrap('No ?change= specified.'); return; }
-  manifest = await (await fetch(`${base}/manifest.json`)).json();
+  const content = document.getElementById('content');
+  if (!change) { content.innerHTML = '<p class="placeholder">No ?change= specified.</p>'; return; }
+  const manifest = await (await fetch(`${base}/manifest.json`)).json();
   document.getElementById('hname').textContent = manifest.name;
   document.title = `${manifest.name} — Spectra`;
-  homeBtn.onclick = () => select('overview');
-  const tabsEl = document.getElementById('tabs');
-  TABS.forEach(id => {
-    const b = document.createElement('button');
-    b.className = 'tab'; b.textContent = LABELS[id]; b.id = `tab-${id}`;
-    b.setAttribute('role','tab'); b.setAttribute('aria-selected','false'); b.tabIndex = -1;
-    b.onclick = () => select(id);
-    tabsEl.appendChild(b); tabEl[id] = b;
-  });
-  tabsEl.addEventListener('keydown', e => {
-    if (e.key !== 'ArrowRight' && e.key !== 'ArrowLeft') return;
-    const cur = TABS.indexOf(active);
-    const next = TABS[((cur<0?0:cur)+(e.key==='ArrowRight'?1:TABS.length-1))%TABS.length];
-    select(next); tabEl[next].focus(); e.preventDefault();
-  });
-  const t = params.get('tab');
-  select(t === 'overview' || TABS.includes(t) ? t : 'overview');
-}
 
-async function select(id) {
-  active = id;
-  homeBtn.classList.toggle('home-btn', true);
-  for (const t of TABS) { const on = t===id; tabEl[t].setAttribute('aria-selected',on); tabEl[t].tabIndex=on?0:-1; }
-  panel.innerHTML = wrap('Loading…');
-  panel.innerHTML = await renderContent(id);
-  fitIframes();
-  panel.scrollIntoView({block:'start'});
-}
+  const a   = manifest.artifacts || {};
+  const pct = manifest.total ? Math.round(manifest.done / manifest.total * 100) : 0;
+  const avail = x => x && x.html ? '✓ HTML' : x && x.md ? '✓ .md' : '—';
 
-function renderOverview() {
-  const a = manifest.artifacts || {};
-  const pct = manifest.total ? Math.round(manifest.done/manifest.total*100) : 0;
-  const cards = TABS.map(id => `
-    <button class="ov-btn" onclick="select('${id}')">
-      <div class="ov-info">
-        <span class="ov-label">${LABELS[id]}</span>
-        <span class="ov-hint">${HINTS[id]}</span>
-      </div>
-      <span class="ov-stat">${
-        id==='tasks' ? `${manifest.done}/${manifest.total}` :
-        id==='specs' ? (manifest.specs.length ? `${manifest.specs.length} spec` : 'none') :
-        avail(a[id])
-      }</span>
-      <span class="ov-arr">›</span>
-    </button>`).join('');
-  return wrap(`
+  let grid = '';
+  if (a.proposal && (a.proposal.html || a.proposal.md))
+    grid += btn(`${base}/proposal.html`, 'Proposal', 'Why · what · impact', avail(a.proposal));
+  if (a.design && (a.design.html || a.design.md))
+    grid += btn(`${base}/design.html`, 'Design', 'Decisions & contract', avail(a.design));
+  grid += btn(`${base}/tasks.html`, 'Tasks', 'Live checklist', `${manifest.done}/${manifest.total}`);
+  if (a.review && (a.review.html || a.review.md))
+    grid += btn(`${base}/review.html`, 'Review', 'Post-apply verdict', avail(a.review));
+
+  let specsHtml = '';
+  if (manifest.specs && manifest.specs.length) {
+    specsHtml = '<p class="ov-sec" id="specs">Specs</p>';
+    for (const s of manifest.specs)
+      specsHtml += btn(`${base}/specs/${esc(s.name)}/spec.html`, s.name, 'GIVEN/WHEN/THEN scenarios', '✓');
+  }
+
+  content.innerHTML = `
     <h1 class="ov-name">${esc(manifest.name)}</h1>
-    <p class="ov-sum">${esc(manifest.summary||'')}</p>
+    <p class="ov-sum">${esc(manifest.summary || '')}</p>
     <div class="ov-prog">
       <div class="prog-track" role="progressbar" aria-valuenow="${manifest.done}" aria-valuemin="0" aria-valuemax="${manifest.total}">
         <div class="prog-fill" style="width:${pct}%"></div>
       </div>
       <span class="prog-label">${manifest.done}/${manifest.total} tasks · ${pct}%</span>
     </div>
-    <div class="ov-grid">${cards}</div>`);
+    <div class="ov-grid">${grid}</div>
+    ${specsHtml}`;
+
+  if (location.hash === '#specs') document.getElementById('specs')?.scrollIntoView();
 }
 
-async function renderContent(id) {
-  if (id === 'overview') return renderOverview();
-  if (id === 'tasks') { const md = await fetchText(`${base}/tasks.md`); return md==null?placeholder('No tasks.md.'):wrap(renderMd(md)); }
-  if (id === 'specs') {
-    if (!manifest.specs.length) return placeholder('No specs in this change.');
-    let out = '';
-    for (const s of manifest.specs) {
-      if (s.html) { out += mkIframe(`${base}/specs/${s.name}/spec.html`,`${s.name} spec`); continue; }
-      const md = await fetchText(`${base}/specs/${s.name}/spec.md`);
-      out += wrap(`<h2>${esc(s.name)}</h2>`+(md==null?`<div class="placeholder">missing spec.md</div>`:renderMd(md)));
-    }
-    return out;
-  }
-  const a = (manifest.artifacts||{})[id]||{};
-  if (a.html) return mkIframe(`${base}/${id}.html`,LABELS[id]);
-  if (a.md) { const md = await fetchText(`${base}/${id}.md`); return md==null?placeholder('missing'):wrap(renderMd(md)); }
-  return placeholder(`No ${LABELS[id]} authored yet.`);
-}
-
-// ── iframes ───────────────────────────────────────────────────────────────────
-function fitOne(f) {
-  try {
-    const doc = f.contentWindow.document;
-    // suppress inner scrollbar so only the page scrolls
-    doc.documentElement.style.overflow = 'hidden';
-    if (doc.body) doc.body.style.overflow = 'hidden';
-    // propagate current theme into iframe document
-    injectIframe(f, getTheme());
-    f.style.height = '0';
-    f.style.height = Math.max(doc.documentElement.scrollHeight, doc.body ? doc.body.scrollHeight : 0) + 'px';
-  } catch(e) {}
-}
-function fitIframes() {
-  for (const f of panel.querySelectorAll('iframe.auto')) {
-    f.addEventListener('load', () => fitOne(f));
-    if (f.contentWindow?.document?.readyState === 'complete') fitOne(f);
-  }
-}
-let rt;
-addEventListener('resize', () => { clearTimeout(rt); rt = setTimeout(() => panel.querySelectorAll('iframe.auto').forEach(fitOne), 120); });
-
-load().catch(e => { panel.innerHTML = wrap('Error: ' + e.message); });
+load().catch(e => { document.getElementById('content').innerHTML = `<p class="placeholder">Error: ${esc(e.message)}</p>`; });
 </script>
 </body>
 </html>

--- a/docs/shell.html
+++ b/docs/shell.html
@@ -15,13 +15,16 @@
 *{box-sizing:border-box}
 body{margin:0;font:15px/1.65 'Bricolage Grotesque',system-ui,sans-serif;background:var(--bg);color:var(--text);-webkit-font-smoothing:antialiased}
 .bar{position:sticky;top:0;z-index:10;background:color-mix(in srgb,var(--bg) 90%,transparent);backdrop-filter:blur(14px);border-bottom:1px solid var(--border)}
-.bar-in{display:flex;align-items:center;gap:6px;max-width:1140px;margin:0 auto;padding:0 18px;min-height:50px}
+.bar-in{display:flex;align-items:center;gap:4px;max-width:1140px;margin:0 auto;padding:0 18px;min-height:50px}
 .btn{appearance:none;background:none;border:0;cursor:pointer;font-size:14px;font-family:'Bricolage Grotesque',system-ui,sans-serif;color:var(--muted);padding:5px 9px;border-radius:6px;text-decoration:none;white-space:nowrap;line-height:1.4}
 .btn:hover{color:var(--text);background:var(--surface)}
 .btn:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
 .name{font-family:'IBM Plex Mono',monospace;font-size:12px;font-weight:500;letter-spacing:-.2px;color:var(--text)}
 .sep{width:1px;height:14px;background:var(--border);margin:0 2px;flex-shrink:0}
-.theme-pill{appearance:none;background:var(--surface);border:1px solid var(--border);cursor:pointer;font-size:13px;padding:3px 10px;border-radius:20px;color:var(--muted);margin-left:auto;flex-shrink:0;transition:border-color .12s;line-height:1.6}
+.tabs{display:flex;align-items:flex-end;height:50px;margin-left:auto;overflow-x:auto}
+.tab{appearance:none;background:none;border:0;border-bottom:2px solid transparent;color:var(--muted);padding:6px 11px;font:13px/1 'Bricolage Grotesque',system-ui,sans-serif;cursor:pointer;height:100%;white-space:nowrap;text-decoration:none;display:inline-flex;align-items:center;transition:color .12s,border-color .12s}
+.tab:hover{color:var(--text)}
+.theme-pill{appearance:none;background:var(--surface);border:1px solid var(--border);cursor:pointer;font-size:13px;padding:3px 10px;border-radius:20px;color:var(--muted);margin-left:8px;flex-shrink:0;transition:border-color .12s;line-height:1.6}
 .theme-pill:hover{border-color:var(--accent);color:var(--text)}
 main{min-height:60vh}
 .wrap{max-width:900px;margin:0 auto;padding:28px 20px 72px}
@@ -51,6 +54,7 @@ main{min-height:60vh}
     <a class="btn" href="index.html">← All</a>
     <span class="sep" aria-hidden="true"></span>
     <span class="btn name" id="hname">…</span>
+    <nav class="tabs" id="tabs" aria-label="Artifacts"></nav>
     <button class="theme-pill" id="themeBtn" title="Toggle theme" aria-label="Toggle theme"></button>
   </div>
 </header>
@@ -59,12 +63,22 @@ main{min-height:60vh}
 </main>
 
 <script>
+const DARK  = '--bg:#0c0c10;--surface:#14141c;--border:#22222e;--text:#e2e2f0;--muted:#7878a0;--accent:#818cf8;--ok:#34d399;--warn:#fbbf24;--bad:#f87171;--fg:#e2e2f0;--card:#14141c;--line:#22222e;--mut:#7878a0';
+const LIGHT = '--bg:#f4f4f9;--surface:#ffffff;--border:#dddde8;--text:#1a1a2e;--muted:#6868a0;--accent:#6366f1;--ok:#059669;--warn:#d97706;--bad:#dc2626;--fg:#1a1a2e;--card:#ffffff;--line:#dddde8;--mut:#6868a0';
+
 const themeBtn = document.getElementById('themeBtn');
 const sys = () => matchMedia('(prefers-color-scheme:dark)').matches ? 'dark' : 'light';
-function getTheme() { return document.documentElement.dataset.theme || sys(); }
-function applyTheme(t) { document.documentElement.dataset.theme = t; themeBtn.textContent = t === 'dark' ? '☀' : '☾'; }
+function getTheme() { return localStorage.getItem('theme') || sys(); }
+function applyTheme(t) {
+  document.documentElement.dataset.theme = t;
+  (t === 'dark' ? DARK : LIGHT).split(';').forEach(v => {
+    const [k, val] = v.split(':');
+    if (k && val) document.documentElement.style.setProperty(k.trim(), val.trim());
+  });
+  themeBtn.textContent = t === 'dark' ? '☀' : '☾';
+}
 themeBtn.onclick = () => { const n = getTheme() === 'dark' ? 'light' : 'dark'; localStorage.setItem('theme', n); applyTheme(n); };
-applyTheme(localStorage.getItem('theme') || sys());
+applyTheme(getTheme());
 
 const params = new URLSearchParams(location.search);
 const change = params.get('change');
@@ -85,23 +99,39 @@ async function load() {
   document.getElementById('hname').textContent = manifest.name;
   document.title = `${manifest.name} — Spectra`;
 
-  const a   = manifest.artifacts || {};
-  const pct = manifest.total ? Math.round(manifest.done / manifest.total * 100) : 0;
+  const a    = manifest.artifacts || {};
+  const specs = manifest.specs || [];
+  const pct  = manifest.total ? Math.round(manifest.done / manifest.total * 100) : 0;
   const avail = x => x && x.html ? '✓ HTML' : x && x.md ? '✓ .md' : '—';
 
+  // Build tabs nav
+  const tabDefs = [];
+  if (a.proposal?.html || a.proposal?.md) tabDefs.push(['proposal', 'Proposal']);
+  if (specs.length === 1) tabDefs.push([`specs/${specs[0].name}/spec`, 'Spec']);
+  else if (specs.length > 1) tabDefs.push(['#specs', `Specs (${specs.length})`]);
+  if (a.design?.html || a.design?.md) tabDefs.push(['design', 'Design']);
+  tabDefs.push(['tasks', 'Tasks']);
+  if (a.review?.html || a.review?.md) tabDefs.push(['review', 'Review']);
+
+  document.getElementById('tabs').innerHTML = tabDefs.map(([id, label]) => {
+    const href = id.startsWith('#') ? id : `${base}/${id}.html`;
+    return `<a class="tab" href="${esc(href)}">${esc(label)}</a>`;
+  }).join('');
+
+  // Build overview grid
   let grid = '';
-  if (a.proposal && (a.proposal.html || a.proposal.md))
+  if (a.proposal?.html || a.proposal?.md)
     grid += btn(`${base}/proposal.html`, 'Proposal', 'Why · what · impact', avail(a.proposal));
-  if (a.design && (a.design.html || a.design.md))
+  if (a.design?.html || a.design?.md)
     grid += btn(`${base}/design.html`, 'Design', 'Decisions & contract', avail(a.design));
   grid += btn(`${base}/tasks.html`, 'Tasks', 'Live checklist', `${manifest.done}/${manifest.total}`);
-  if (a.review && (a.review.html || a.review.md))
+  if (a.review?.html || a.review?.md)
     grid += btn(`${base}/review.html`, 'Review', 'Post-apply verdict', avail(a.review));
 
   let specsHtml = '';
-  if (manifest.specs && manifest.specs.length) {
+  if (specs.length) {
     specsHtml = '<p class="ov-sec" id="specs">Specs</p>';
-    for (const s of manifest.specs)
+    for (const s of specs)
       specsHtml += btn(`${base}/specs/${esc(s.name)}/spec.html`, s.name, 'GIVEN/WHEN/THEN scenarios', '✓');
   }
 


### PR DESCRIPTION
Extends the spec-pages index to include a dedicated **Archived** section below the active changes grid.

## Changes

**`spec-pages.yml` Python script:**
- Scan `docs/changes/archive/` in addition to active changes (sorted newest-first)
- Parse `YYYY-MM-DD-<name>` directory names to extract `archivedAt` date and change name
- Build + copy archived artifacts to `.pages-build/changes/archive/<dir>/`
- Generate `manifest.json` per archived change with `archivedAt` field

**`index.html` template:**
- Active changes: unchanged full card layout
- Archived section: "ARCHIVED N ───" divider + compact rows (name · truncated summary · archive date · PR badge)
- Archived rows link to `shell.html?change=archive/<dir-name>` — shell resolves `changes/${change}` correctly with no modification
- Section is omitted when archive is empty

---

**zh-tw 摘要**：擴充 spec-pages index，在 active changes 下方加入「ARCHIVED N ───」分隔列與緊湊 row 樣式的歸檔項目，點擊可進入 shell 查看完整 artifacts。CI 掃描 `docs/changes/archive/` 目錄，解析 `YYYY-MM-DD-<name>` 格式取得歸檔日期，不需修改 shell.html。