### PR TITLE
ci(claude-review): skip review on docs-only changes

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,6 +3,8 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize]
+    paths-ignore:
+      - "docs/**"
 
 jobs:
   claude-review:


### PR DESCRIPTION
## Summary

Add `paths-ignore: docs/**` to the `pull_request` trigger of the Claude Code Review workflow, so docs-only PRs (e.g. spec-loop artifact updates) don't trigger a code review run.

This also lets the action's workflow-validation pass on feature PRs such as #311: the anti-tampering check compares the workflow file on the PR branch against the default branch, so the two-line change must land on `main` first.

Scope is intentionally minimal — one file, two lines. Isolated from the unrelated `spec-pages.yml` changes that were bundled in the original commit.

## 中文摘要

在 Claude Code Review workflow 的 `pull_request` 觸發條件加上 `paths-ignore: docs/**`，讓純文件（docs-only）PR 不再觸發 code review。此變更也讓 action 的 workflow-validation 能在 #311 等 feature PR 通過（anti-tampering 會比對 PR 分支與預設分支上的 workflow 檔，故這 2 行需先進 `main`）。刻意只改 1 檔 2 行，並與原 commit 夾帶的 `spec-pages.yml` 變更隔離。
