### PR TITLE
fix(game): pin loading skeleton drawer peek to 80px

### DIFF
--- a/src/components/game/index.tsx
+++ b/src/components/game/index.tsx
@@ -66,7 +66,7 @@ const Game = ({ gameId, setIndex }: { gameId: string; setIndex: number }) => {
           fill the rest. The drawer is a vaul snap-point sheet portalled to
           <body> (fixed at the bottom), so pb reserves its idle peek height and
           the panel content never sits behind the peek. */}
-      <div className="flex min-h-0 w-full flex-1 flex-col gap-1 pt-[calc(env(safe-area-inset-top)+5.5rem)] pb-[5.25rem]">
+      <div className="flex min-h-0 w-full flex-1 flex-col gap-1 pt-[calc(env(safe-area-inset-top)+5.5rem)] pb-21">
         <div className="w-full shrink-0 overflow-hidden rounded-lg">
           <GameCourt gameId={gameId} mode="general" />
         </div>
@@ -98,7 +98,7 @@ export function GameSkeleton() {
   return (
     <div className="flex h-full w-full max-w-160 flex-col items-center justify-start overflow-hidden">
       <GameHeader />
-      <div className="flex min-h-0 w-full flex-1 flex-col gap-1 pt-[calc(env(safe-area-inset-top)+5.5rem)] pb-[5.25rem]">
+      <div className="flex min-h-0 w-full flex-1 flex-col gap-1 pt-[calc(env(safe-area-inset-top)+5.5rem)] pb-21">
         <div className="w-full shrink-0 overflow-hidden rounded-lg">
           <LoadingCourt />
         </div>
@@ -114,13 +114,16 @@ export function GameSkeleton() {
         </div>
       </div>
       {/* mirrors the drawer idle peek fixed at the viewport bottom: handle +
-          Preview-shaped row on the drawer (bg-card) surface. */}
-      <div className="fixed inset-x-0 bottom-0 z-40 mx-auto w-full max-w-160 rounded-t-[10px] bg-card">
+          one entry-row-shaped skeleton on the drawer (bg-card) surface. Height
+          is pinned to PEEK_SNAP (80px = h-20) so the peek's top edge lands where
+          the real drawer sits and the ~20px breathing room below the row matches
+          -- no gap above the peek and no jump when the real drawer mounts. */}
+      <div className="fixed inset-x-0 bottom-0 z-40 mx-auto h-20 w-full max-w-160 rounded-t-[10px] bg-card">
         <div className="pt-2 pb-1.5">
           <Skeleton className="mx-auto h-1.5 w-10 rounded-full" />
         </div>
-        <div className="grid w-full px-2 pb-2">
-          <Skeleton className="h-8 w-full" />
+        <div className="grid w-full px-2">
+          <Skeleton className="h-10 w-full" />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## What

The `GameSkeleton` bottom drawer peek rendered at ~60px, while the live `SummaryDrawer` peek (`PEEK_SNAP`) and the layout's reserved bottom padding are 80px / 84px. The 20px shortfall showed as a visible gap above the peek in the loading state and a layout jump when the real drawer mounted.

## Fix

- Pin the skeleton peek container to `h-20` (80px) so its top edge lands where the live drawer sits.
- Reshape the row skeleton (`h-10`) so the ~20px breathing room below it matches the live peek.
- Normalize the reserved bottom padding from arbitrary `[5.25rem]` to the `pb-21` scale step in both the ready and skeleton layouts.

CSS-only, no logic change. Leftover polish from the merged `entry-ui` change (game/summary-drawer). Visually verified on device against the live recording screen.

## Verify

- `pnpm typecheck` — green
- Visual: skeleton now mirrors the live game screen; no gap above the peek, no jump on load.

---

### 中文摘要

修正 game 載入 skeleton 的底部 drawer peek 高度：原本 ~60px，比實際 `SummaryDrawer` peek（`PEEK_SNAP` 80px）與版面保留的 `pb`（84px）矮 20px，導致 peek 上方出現空隙、且真實 drawer 掛載時畫面跳動。將 peek 容器釘為 `h-20`(80px)、row 撐到 `h-10`，底部留白與實際一致；並把保留 padding 從 `[5.25rem]` 正規化為 `pb-21`。純 CSS，無邏輯變動，屬已併入的 `entry-ui` 收尾。已於裝置上對照實際錄影畫面視覺驗證。