### PR TITLE
ci(changesets): run release job on Node 22 [skip review]

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -20,7 +20,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          # pnpm 11 requires Node >= 22.13 (engines is >=22)
+          node-version: 22
           cache: "pnpm"
 
       - run: pnpm install --frozen-lockfile


### PR DESCRIPTION
The changesets release job failed on the push from #321: pnpm 11 requires Node >= 22.13 but the job pinned Node 20, so `pnpm install` aborted before changesets/action could open the version PR.

Bumping the job to Node 22 (matching `engines: >=22`). Merging this PR pushes to `main` and re-triggers the Changesets workflow, which will then consume the 9 pending changesets and open the `release: update versions [skip review]` PR for 0.14.0.

---

**zh-tw 摘要**：changesets release job 因 Node 20 與 pnpm 11（需 ≥22.13）不相容而在 install 階段失敗，0.14.0 的版本 PR 未能開出。本 PR 將 job 升至 Node 22；merge 後 workflow 會重新觸發並自動開出版本 PR。