### PR TITLE
ci: gate PRs on verify, tests, and builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,13 @@ on:
       - dev
       - main
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   verify:
     name: Verify

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - dev
+      - main
+
+jobs:
+  verify:
+    name: Verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      # next build imports route modules while collecting page data, which
+      # validates this variable's presence; no real connection is made.
+      MONGODB_URI: mongodb://localhost:27017/ci-placeholder
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          # pnpm 11 requires Node >= 22.13 (engines is >=22)
+          node-version: 22
+          cache: "pnpm"
+
+      - run: pnpm install --frozen-lockfile
+
+      # format:check + typecheck (TS7 native via tsgo) + lint + test
+      - run: pnpm verify
+
+      - run: pnpm --filter blueprint test
+
+      - run: pnpm build
+
+      - run: pnpm --filter blueprint build


### PR DESCRIPTION
Adds `.github/workflows/ci.yml`: every PR to `dev`/`main` now runs the maintenance policy's verification checklist automatically —

1. `pnpm verify` (prettier check, TS7-native typecheck, eslint, jest: 98 suites)
2. `pnpm --filter blueprint test`
3. `pnpm build` (app, with placeholder `MONGODB_URI` — page-data collection only checks presence)
4. `pnpm --filter blueprint build`

Node 22 (pnpm 11 requires ≥22.13), pnpm store cached via setup-node.

Closes the gap flagged in the PR #320 review: the checklist previously relied entirely on local runs self-reported in PR descriptions. Making these required status checks on `dev` needs a branch-protection settings change (repo Settings → Branches) — not doable from workflow files; noted in Paca VB-53.

This PR intentionally lets the new workflow run on itself as a live test.

---

**zh-tw 摘要**：新增 CI workflow，所有 PR to dev/main 自動跑 verify（format/typecheck/lint/test）+ blueprint 測試 + 雙 build。要把它設成 required status check 需到 repo Settings → Branches 手動設定。