### PR TITLE
chore: sync wrangler worker name fix back to dev [skip review]

### DIFF
--- a/blueprint/wrangler.toml
+++ b/blueprint/wrangler.toml
@@ -1,4 +1,4 @@
-name = "blueprint"
+name = "volleybro-blueprint"
 compatibility_date = "2026-07-01"
 
 [assets]


### PR DESCRIPTION
Sync #323 (Cloudflare bot: `blueprint/wrangler.toml` name → `volleybro-blueprint`) from main into dev so dev-branch Cloudflare builds target the same Worker.

---

**zh-tw 摘要**：把 #323 的 Worker 名稱修正同步回 dev，避免 dev 分支的 Cloudflare build 因名稱不一致另建 Worker。