### PR TITLE
ci(changesets): auto-tag, GitHub Release, and dev sync after release

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -27,11 +27,29 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - uses: changesets/action@v1
+        id: changesets
         with:
           version: pnpm run release:version
+          # changeset tag creates vX.Y.Z for the current version; the action
+          # pushes the tag and creates the GitHub Release from CHANGELOG.md.
+          # Runs only when no changesets are pending (i.e. after the version
+          # PR merges) and skips tags that already exist, so it is idempotent.
+          publish: pnpm run release:publish
           commit: "release: update versions"
           # [skip review] keeps the auto-opened release PR out of claude-code-review
           title: "release: update versions [skip review]"
           createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sync release back to dev
+        if: steps.changesets.outputs.published == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          version=$(node -p "require('./package.json').version")
+          pr=$(gh pr create --base dev --head main \
+            --title "chore: sync v${version} release back to dev [skip review]" \
+            --body "Automated sync of the v${version} release commit (version bump, CHANGELOG entry, consumed changeset deletions) from main back into dev.")
+          gh pr merge --merge "$pr" \
+            || echo "::warning::Could not auto-merge the sync PR (likely a conflict); merge it manually: $pr"

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -48,8 +48,11 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           version=$(node -p "require('./package.json').version")
-          pr=$(gh pr create --base dev --head main \
+          if pr=$(gh pr create --base dev --head main \
             --title "chore: sync v${version} release back to dev [skip review]" \
-            --body "Automated sync of the v${version} release commit (version bump, CHANGELOG entry, consumed changeset deletions) from main back into dev.")
-          gh pr merge --merge "$pr" \
-            || echo "::warning::Could not auto-merge the sync PR (likely a conflict); merge it manually: $pr"
+            --body "Automated sync of the v${version} release commit (version bump, CHANGELOG entry, consumed changeset deletions) from main back into dev." 2>&1); then
+            gh pr merge --merge "$pr" \
+              || echo "::warning::Could not auto-merge the sync PR (conflict or merge restriction); merge it manually: $pr"
+          else
+            echo "::warning::Could not open the sync PR (possibly already open, or nothing to sync): $pr"
+          fi

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "build-storybook": "storybook build",
     "chromatic": "npx chromatic",
     "release:version": "changeset version && node .changeset/changelog-postprocess.cjs",
+    "release:publish": "changeset tag",
     "blueprint": "node scripts/blueprint.mjs"
   },
   "dependencies": {


### PR DESCRIPTION
Closes the two manual steps left from the 0.14.0 release (Paca VB-56):

1. **Tags & GitHub Releases**: `createGithubReleases: true` was a silent no-op — changesets/action only pushes tags and creates Releases when a `publish` command runs ([changesets/action#269](https://github.com/changesets/action/issues/269)). Wired `publish: pnpm run release:publish` (= `changeset tag`). It only produces a new tag right after a version PR merges, and skips existing tags (idempotent).
2. **main→dev sync**: when `steps.changesets.outputs.published == 'true'`, a follow-up step opens `chore: sync vX.Y.Z release back to dev [skip review]` and merges it; on conflict it leaves the PR open with a workflow warning instead of failing.

**Watch item for v0.15.0**: first live run of the `changeset tag` → `published` output path. If the sync step doesn't fire, fall back to the manual sync used for 0.14.0.

---

**zh-tw 摘要**：補上 release 自動化兩缺口——version PR merge 後自動打 tag + 建 GitHub Release；release 後自動開並 merge main→dev sync PR（衝突時留給人工）。v0.15.0 為首次實跑，需觀察。