### PR TITLE
ci(changesets): sync release to dev via server-side merge

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -48,11 +48,10 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           version=$(node -p "require('./package.json').version")
-          if pr=$(gh pr create --base dev --head main \
-            --title "chore: sync v${version} release back to dev [skip review]" \
-            --body "Automated sync of the v${version} release commit (version bump, CHANGELOG entry, consumed changeset deletions) from main back into dev." 2>&1); then
-            gh pr merge --merge "$pr" \
-              || echo "::warning::Could not auto-merge the sync PR (conflict or merge restriction); merge it manually: $pr"
-          else
-            echo "::warning::Could not open the sync PR (possibly already open, or nothing to sync): $pr"
-          fi
+          # Server-side merge of main into dev -- no PR, no local git state.
+          # 409 on conflict, 4xx if a ruleset blocks the push; both degrade
+          # to a warning for manual handling.
+          gh api "repos/${{ github.repository }}/merges" \
+            -f base=dev -f head=main \
+            -f commit_message="chore: sync v${version} release back to dev [skip review]" \
+            || echo "::warning::Could not merge main into dev (conflict or ruleset restriction); sync manually."


### PR DESCRIPTION
Replaces the PR-based main→dev release sync with a server-side merge (`POST /repos/{repo}/merges`) — no PR, no checkout, one less thing to click.

**Requires a ruleset change to actually work**: the new dev ruleset requires the Verify status check on ref updates, which blocks any direct push — including this API merge and (as discovered pushing this very commit) local pushes to dev. For the release automation to function, add the **GitHub Actions** app to the dev ruleset's bypass list. Humans and agents keep going through PRs; only the release sync bypasses.

Degrades to a workflow warning (manual sync) on conflict or if the bypass isn't configured.

---

**zh-tw 摘要**：release sync 改為 server-side merge（免開 PR）。需在 dev ruleset 的 bypass list 加入 GitHub Actions app 才會生效——否則 sync 會被 Verify required check 擋下並降級為 warning。