### PR TITLE
fix(stories): freeze calendar month and today marker for Chromatic [skip review]

### DIFF
--- a/src/stories/ui/calendar.stories.tsx
+++ b/src/stories/ui/calendar.stories.tsx
@@ -13,6 +13,10 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+// Freeze every date-dependent aspect of the render: `selected` alone is not
+// enough — without `defaultMonth` the calendar opens on the real current
+// month, and without `today` the today-marker circles the real current day,
+// shifting one cell per day and tripping Chromatic's visual regression.
 const FIXED_DATE = new Date("2025-01-15");
 
 export const Default: Story = {
@@ -23,6 +27,8 @@ export const Default: Story = {
         mode="single"
         selected={date}
         onSelect={setDate}
+        defaultMonth={FIXED_DATE}
+        today={FIXED_DATE}
         className="rounded-md border"
       />
     );
@@ -37,6 +43,8 @@ export const Range: Story = {
         mode="range"
         selected={range}
         onSelect={setRange}
+        defaultMonth={FIXED_DATE}
+        today={FIXED_DATE}
         className="rounded-md border"
       />
     );
@@ -51,6 +59,8 @@ export const WithDisabledDates: Story = {
         mode="single"
         selected={date}
         onSelect={setDate}
+        defaultMonth={FIXED_DATE}
+        today={FIXED_DATE}
         disabled={{ dayOfWeek: [0, 6] }}
         className="rounded-md border"
       />


### PR DESCRIPTION
Root cause of the perpetual calendar visual-regression flakes: `FIXED_DATE` only pinned `selected` — the displayed month still defaulted to the real current month, and the today marker circled the real current day (shifting one cell per day). `Range` had nothing pinned at all.

Pin `defaultMonth` + `today` on all three stories. After merge, accept the resulting Chromatic baselines once — snapshots are deterministic from then on.

Story-only mechanical fix, hence the review skip.

---

**zh-tw 摘要**：calendar story 只固定了 selected，顯示月份與 today 標記仍跟真實日期跑（today 每天移一格）——補 `defaultMonth` + `today` 讓渲染完全確定性。merge 後到 Chromatic 接受最後一次 baseline 即可。