### PR TITLE
refactor(errors): restore barrel and consolidate error imports [skip review]

### DIFF
--- a/src/app/api/games/route.ts
+++ b/src/app/api/games/route.ts
@@ -1,5 +1,4 @@
-import { ValidationError } from "@/entities/errors/app-error";
-import { CommonReason } from "@/entities/errors/reasons/common";
+import { ValidationError, CommonReason } from "@/entities/errors";
 import { connectToMongoDB } from "@/infrastructure/db/mongoose/connect-to-mongodb";
 import { findGameSummariesController } from "@/interface/controllers/game/game-summary.controller";
 import { createGameController } from "@/interface/controllers/game/game.controller";

--- a/src/app/api/profiles/route.ts
+++ b/src/app/api/profiles/route.ts
@@ -5,8 +5,7 @@ import {
   getProfileController,
   updateProfileController,
 } from "@/interface/controllers/user/profile.controller";
-import { NotFoundError } from "@/entities/errors/app-error";
-import { ProfileReason } from "@/entities/errors/reasons/profile";
+import { NotFoundError, ProfileReason } from "@/entities/errors";
 import { NextResponse, type NextRequest } from "next/server";
 
 export const dynamic = "force-dynamic";

--- a/src/app/api/teams/[teamId]/route.ts
+++ b/src/app/api/teams/[teamId]/route.ts
@@ -1,6 +1,5 @@
 import type { IAuthorizationService } from "@/applications/services/auth/authorization.service.interface";
-import { NotFoundError } from "@/entities/errors/app-error";
-import { CommonReason } from "@/entities/errors/reasons/common";
+import { NotFoundError, CommonReason } from "@/entities/errors";
 import { connectToMongoDB } from "@/infrastructure/db/mongoose/connect-to-mongodb";
 import { container } from "@/infrastructure/di/inversify.config";
 import { TYPES } from "@/infrastructure/di/types";

--- a/src/app/api/teams/route.ts
+++ b/src/app/api/teams/route.ts
@@ -1,5 +1,4 @@
-import { AuthenticationError } from "@/entities/errors/app-error";
-import { AuthReason } from "@/entities/errors/reasons/auth";
+import { AuthenticationError, AuthReason } from "@/entities/errors";
 import { connectToMongoDB } from "@/infrastructure/db/mongoose/connect-to-mongodb";
 import { createTeamController } from "@/interface/controllers/team/team.controller";
 import { withErrorHandler } from "@/lib/api/wrappers";

--- a/src/app/api/users/[userId]/players/route.ts
+++ b/src/app/api/users/[userId]/players/route.ts
@@ -2,8 +2,7 @@
  * GET /api/users/{userId}/players - Retrieve all teams/players for a user
  */
 
-import { AuthorizationError } from "@/entities/errors/app-error";
-import { AuthReason } from "@/entities/errors/reasons/auth";
+import { AuthorizationError, AuthReason } from "@/entities/errors";
 import * as playerController from "@/interface/controllers/player/player.controller";
 import { withAuth } from "@/lib/api/wrappers";
 import { PlayerSchema } from "@/lib/validations/player";

--- a/src/applications/types/result.ts
+++ b/src/applications/types/result.ts
@@ -1,3 +1,3 @@
-import type { AppError } from "@/entities/errors/app-error";
+import { type AppError } from "@/entities/errors";
 
 export type Result<T> = { ok: true; value: T } | { ok: false; error: AppError };

--- a/src/applications/usecases/game/__tests__/create-rally.usecase.test.ts
+++ b/src/applications/usecases/game/__tests__/create-rally.usecase.test.ts
@@ -6,7 +6,7 @@ import {
   createUser,
 } from "@/__tests__/helpers";
 import { CreateRallyUseCase } from "@/applications/usecases/game/create-rally.usecase";
-import { NotFoundError } from "@/entities/errors/app-error";
+import { NotFoundError } from "@/entities/errors";
 import { EntryType, MoveType, Rally, TeamStatsClass } from "@/entities/game";
 import { beforeEach, describe, expect, it } from "@jest/globals";
 

--- a/src/applications/usecases/game/__tests__/create-set.usecase.test.ts
+++ b/src/applications/usecases/game/__tests__/create-set.usecase.test.ts
@@ -5,7 +5,7 @@ import {
   createUser,
 } from "@/__tests__/helpers";
 import { CreateSetUseCase } from "@/applications/usecases/game/create-set.usecase";
-import { NotFoundError } from "@/entities/errors/app-error";
+import { NotFoundError } from "@/entities/errors";
 import { Set } from "@/entities/game";
 import { Lineup } from "@/entities/team";
 import { beforeEach, describe, expect, it } from "@jest/globals";

--- a/src/applications/usecases/game/__tests__/create-substitution.usecase.test.ts
+++ b/src/applications/usecases/game/__tests__/create-substitution.usecase.test.ts
@@ -6,7 +6,7 @@ import {
   createUser,
 } from "@/__tests__/helpers";
 import { CreateSubstitutionUseCase } from "@/applications/usecases/game/create-substitution.usecase";
-import { NotFoundError } from "@/entities/errors/app-error";
+import { NotFoundError } from "@/entities/errors";
 import { Substitution } from "@/entities/game";
 import { beforeEach, describe, expect, it } from "@jest/globals";
 

--- a/src/applications/usecases/game/__tests__/find-game.usecase.test.ts
+++ b/src/applications/usecases/game/__tests__/find-game.usecase.test.ts
@@ -5,7 +5,7 @@ import {
   createUser,
 } from "@/__tests__/helpers";
 import { FindGameUseCase } from "@/applications/usecases/game/find-game.usecase";
-import { NotFoundError } from "@/entities/errors/app-error";
+import { NotFoundError } from "@/entities/errors";
 import { beforeEach, describe, expect, it } from "@jest/globals";
 
 let mockGameRepository: ReturnType<typeof createMockGameRepository>;

--- a/src/applications/usecases/game/__tests__/update-rally.usecase.test.ts
+++ b/src/applications/usecases/game/__tests__/update-rally.usecase.test.ts
@@ -6,7 +6,7 @@ import {
   createUser,
 } from "@/__tests__/helpers";
 import { UpdateRallyUseCase } from "@/applications/usecases/game/update-rally.usecase";
-import { NotFoundError } from "@/entities/errors/app-error";
+import { NotFoundError } from "@/entities/errors";
 import { EntryType, MoveType, Rally, TeamStatsClass } from "@/entities/game";
 import { beforeEach, describe, expect, it } from "@jest/globals";
 

--- a/src/applications/usecases/game/__tests__/update-set.usecase.test.ts
+++ b/src/applications/usecases/game/__tests__/update-set.usecase.test.ts
@@ -6,7 +6,7 @@ import {
   createUser,
 } from "@/__tests__/helpers";
 import { UpdateSetUseCase } from "@/applications/usecases/game/update-set.usecase";
-import { NotFoundError } from "@/entities/errors/app-error";
+import { NotFoundError } from "@/entities/errors";
 import { Set } from "@/entities/game";
 import { beforeEach, describe, expect, it } from "@jest/globals";
 

--- a/src/applications/usecases/game/create-rally.usecase.ts
+++ b/src/applications/usecases/game/create-rally.usecase.ts
@@ -1,8 +1,7 @@
 import type { IGameRepository } from "@/applications/repositories/game.repository.interface";
 import type { IAuthenticationService } from "@/applications/services/auth/authentication.service.interface";
 import type { IAuthorizationService } from "@/applications/services/auth/authorization.service.interface";
-import { NotFoundError } from "@/entities/errors/app-error";
-import { GameReason } from "@/entities/errors/reasons/game";
+import { NotFoundError, GameReason } from "@/entities/errors";
 import type { Entry, Rally } from "@/entities/game";
 import { PlayerRole } from "@/entities/player";
 import { TYPES } from "@/infrastructure/di/types";

--- a/src/applications/usecases/game/create-set.usecase.ts
+++ b/src/applications/usecases/game/create-set.usecase.ts
@@ -1,8 +1,7 @@
 import type { IGameRepository } from "@/applications/repositories/game.repository.interface";
 import type { IAuthenticationService } from "@/applications/services/auth/authentication.service.interface";
 import type { IAuthorizationService } from "@/applications/services/auth/authorization.service.interface";
-import { NotFoundError } from "@/entities/errors/app-error";
-import { GameReason } from "@/entities/errors/reasons/game";
+import { NotFoundError, GameReason } from "@/entities/errors";
 import {
   type Game,
   type Set,

--- a/src/applications/usecases/game/create-substitution.usecase.ts
+++ b/src/applications/usecases/game/create-substitution.usecase.ts
@@ -1,8 +1,7 @@
 import type { IGameRepository } from "@/applications/repositories/game.repository.interface";
 import type { IAuthenticationService } from "@/applications/services/auth/authentication.service.interface";
 import type { IAuthorizationService } from "@/applications/services/auth/authorization.service.interface";
-import { NotFoundError } from "@/entities/errors/app-error";
-import { GameReason } from "@/entities/errors/reasons/game";
+import { NotFoundError, GameReason } from "@/entities/errors";
 import {
   type Entry,
   type Game,

--- a/src/applications/usecases/game/find-game.usecase.ts
+++ b/src/applications/usecases/game/find-game.usecase.ts
@@ -1,8 +1,7 @@
 import type { IGameRepository } from "@/applications/repositories/game.repository.interface";
 import type { IAuthenticationService } from "@/applications/services/auth/authentication.service.interface";
 import type { IAuthorizationService } from "@/applications/services/auth/authorization.service.interface";
-import { NotFoundError } from "@/entities/errors/app-error";
-import { GameReason } from "@/entities/errors/reasons/game";
+import { NotFoundError, GameReason } from "@/entities/errors";
 import type { Game } from "@/entities/game";
 import { PlayerRole } from "@/entities/player";
 import { TYPES } from "@/infrastructure/di/types";

--- a/src/applications/usecases/game/update-rally.usecase.ts
+++ b/src/applications/usecases/game/update-rally.usecase.ts
@@ -1,8 +1,7 @@
 import type { IGameRepository } from "@/applications/repositories/game.repository.interface";
 import type { IAuthenticationService } from "@/applications/services/auth/authentication.service.interface";
 import type { IAuthorizationService } from "@/applications/services/auth/authorization.service.interface";
-import { NotFoundError } from "@/entities/errors/app-error";
-import { GameReason } from "@/entities/errors/reasons/game";
+import { NotFoundError, GameReason } from "@/entities/errors";
 import type { Entry, Rally } from "@/entities/game";
 import { PlayerRole } from "@/entities/player";
 import { TYPES } from "@/infrastructure/di/types";

--- a/src/applications/usecases/game/update-set.usecase.ts
+++ b/src/applications/usecases/game/update-set.usecase.ts
@@ -1,8 +1,7 @@
 import type { IGameRepository } from "@/applications/repositories/game.repository.interface";
 import type { IAuthenticationService } from "@/applications/services/auth/authentication.service.interface";
 import type { IAuthorizationService } from "@/applications/services/auth/authorization.service.interface";
-import { NotFoundError } from "@/entities/errors/app-error";
-import { GameReason } from "@/entities/errors/reasons/game";
+import { NotFoundError, GameReason } from "@/entities/errors";
 import { type Game, type Set } from "@/entities/game";
 import { PlayerRole } from "@/entities/player";
 import { TYPES } from "@/infrastructure/di/types";

--- a/src/applications/usecases/player/__tests__/accept-invitation.usecase.test.ts
+++ b/src/applications/usecases/player/__tests__/accept-invitation.usecase.test.ts
@@ -4,7 +4,7 @@ import {
   AuthorizationError,
   ConflictError,
   NotFoundError,
-} from "@/entities/errors/app-error";
+} from "@/entities/errors";
 import { PlayerRole, PlayerStatus } from "@/entities/player";
 
 describe("AcceptInvitationUseCase", () => {

--- a/src/applications/usecases/player/__tests__/cancel-invitation.usecase.test.ts
+++ b/src/applications/usecases/player/__tests__/cancel-invitation.usecase.test.ts
@@ -9,7 +9,7 @@ import {
   ConflictError,
   NotFoundError,
   UnexpectedError,
-} from "@/entities/errors/app-error";
+} from "@/entities/errors";
 import { PlayerStatus } from "@/entities/player";
 import { beforeEach, describe, expect, it } from "@jest/globals";
 

--- a/src/applications/usecases/player/__tests__/create-invitation.usecase.test.ts
+++ b/src/applications/usecases/player/__tests__/create-invitation.usecase.test.ts
@@ -9,7 +9,7 @@ import {
   ConflictError,
   NotFoundError,
   UnexpectedError,
-} from "@/entities/errors/app-error";
+} from "@/entities/errors";
 import { PlayerRole, PlayerStatus } from "@/entities/player";
 import { beforeEach, describe, expect, it } from "@jest/globals";
 

--- a/src/applications/usecases/player/__tests__/create-player.usecase.test.ts
+++ b/src/applications/usecases/player/__tests__/create-player.usecase.test.ts
@@ -5,7 +5,7 @@ import {
 } from "@/__tests__/helpers";
 import type { ICreatePlayerUseCase } from "@/applications/usecases/player/create-player.usecase";
 import { CreatePlayerUseCase } from "@/applications/usecases/player/create-player.usecase";
-import { ConflictError } from "@/entities/errors/app-error";
+import { ConflictError } from "@/entities/errors";
 import { PlayerRole, PlayerStatus, Position } from "@/entities/player";
 import { beforeEach, describe, expect, it } from "@jest/globals";
 

--- a/src/applications/usecases/player/__tests__/leave-team.usecase.test.ts
+++ b/src/applications/usecases/player/__tests__/leave-team.usecase.test.ts
@@ -11,7 +11,7 @@ import {
   AuthorizationError,
   NotFoundError,
   UnexpectedError,
-} from "@/entities/errors/app-error";
+} from "@/entities/errors";
 import { PlayerRole, PlayerStatus } from "@/entities/player";
 import { beforeEach, describe, expect, it } from "@jest/globals";
 

--- a/src/applications/usecases/player/__tests__/reject-invitation.usecase.test.ts
+++ b/src/applications/usecases/player/__tests__/reject-invitation.usecase.test.ts
@@ -1,6 +1,6 @@
 import { createMockPlayerRepository, createPlayer } from "@/__tests__/helpers";
 import { RejectInvitationUseCase } from "@/applications/usecases/player/reject-invitation.usecase";
-import { AuthorizationError, NotFoundError } from "@/entities/errors/app-error";
+import { AuthorizationError, NotFoundError } from "@/entities/errors";
 import { PlayerRole, PlayerStatus } from "@/entities/player";
 
 describe("RejectInvitationUseCase", () => {

--- a/src/applications/usecases/player/__tests__/remove-player.usecase.test.ts
+++ b/src/applications/usecases/player/__tests__/remove-player.usecase.test.ts
@@ -6,7 +6,7 @@ import {
 } from "@/__tests__/helpers";
 import type { IRemovePlayerUseCase } from "@/applications/usecases/player/remove-player.usecase";
 import { RemovePlayerUseCase } from "@/applications/usecases/player/remove-player.usecase";
-import { NotFoundError, UnexpectedError } from "@/entities/errors/app-error";
+import { NotFoundError, UnexpectedError } from "@/entities/errors";
 import { beforeEach, describe, expect, it } from "@jest/globals";
 
 describe("RemovePlayerUseCase", () => {

--- a/src/applications/usecases/player/__tests__/transfer-ownership.usecase.test.ts
+++ b/src/applications/usecases/player/__tests__/transfer-ownership.usecase.test.ts
@@ -6,7 +6,7 @@ import {
   ConflictError,
   NotFoundError,
   UnexpectedError,
-} from "@/entities/errors/app-error";
+} from "@/entities/errors";
 import { PlayerRole } from "@/entities/player";
 import { beforeEach, describe, expect, it } from "@jest/globals";
 

--- a/src/applications/usecases/player/__tests__/update-player-info.usecase.test.ts
+++ b/src/applications/usecases/player/__tests__/update-player-info.usecase.test.ts
@@ -5,7 +5,7 @@ import {
 } from "@/__tests__/helpers";
 import type { IUpdatePlayerInfoUseCase } from "@/applications/usecases/player/update-player-info.usecase";
 import { UpdatePlayerInfoUseCase } from "@/applications/usecases/player/update-player-info.usecase";
-import { NotFoundError } from "@/entities/errors/app-error";
+import { NotFoundError } from "@/entities/errors";
 import { Position } from "@/entities/player";
 import { beforeEach, describe, expect, it } from "@jest/globals";
 

--- a/src/applications/usecases/player/__tests__/update-role.usecase.test.ts
+++ b/src/applications/usecases/player/__tests__/update-role.usecase.test.ts
@@ -5,7 +5,7 @@ import {
 } from "@/__tests__/helpers";
 import type { IUpdateRoleUseCase } from "@/applications/usecases/player/update-role.usecase";
 import { UpdateRoleUseCase } from "@/applications/usecases/player/update-role.usecase";
-import { NotFoundError } from "@/entities/errors/app-error";
+import { NotFoundError } from "@/entities/errors";
 import { PlayerRole } from "@/entities/player";
 import { beforeEach, describe, expect, it } from "@jest/globals";
 

--- a/src/applications/usecases/player/accept-invitation.usecase.ts
+++ b/src/applications/usecases/player/accept-invitation.usecase.ts
@@ -3,8 +3,8 @@ import {
   AuthorizationError,
   ConflictError,
   NotFoundError,
-} from "@/entities/errors/app-error";
-import { PlayerReason } from "@/entities/errors/reasons/player";
+  PlayerReason,
+} from "@/entities/errors";
 import { PlayerStatus } from "@/entities/player";
 import { TYPES } from "@/infrastructure/di/types";
 import { inject, injectable } from "inversify";

--- a/src/applications/usecases/player/cancel-invitation.usecase.ts
+++ b/src/applications/usecases/player/cancel-invitation.usecase.ts
@@ -4,9 +4,9 @@ import {
   ConflictError,
   NotFoundError,
   UnexpectedError,
-} from "@/entities/errors/app-error";
-import { CommonReason } from "@/entities/errors/reasons/common";
-import { PlayerReason } from "@/entities/errors/reasons/player";
+  CommonReason,
+  PlayerReason,
+} from "@/entities/errors";
 import type { Player } from "@/entities/player";
 import { PlayerStatus } from "@/entities/player";
 import { TYPES } from "@/infrastructure/di/types";

--- a/src/applications/usecases/player/create-invitation.usecase.ts
+++ b/src/applications/usecases/player/create-invitation.usecase.ts
@@ -4,9 +4,9 @@ import {
   ConflictError,
   NotFoundError,
   UnexpectedError,
-} from "@/entities/errors/app-error";
-import { CommonReason } from "@/entities/errors/reasons/common";
-import { PlayerReason } from "@/entities/errors/reasons/player";
+  CommonReason,
+  PlayerReason,
+} from "@/entities/errors";
 import type { Player } from "@/entities/player";
 import { PlayerRole, PlayerStatus } from "@/entities/player";
 import { TYPES } from "@/infrastructure/di/types";

--- a/src/applications/usecases/player/create-player.usecase.ts
+++ b/src/applications/usecases/player/create-player.usecase.ts
@@ -1,8 +1,11 @@
 import type { IPlayerRepository } from "@/applications/repositories/player.repository.interface";
 import type { IAuthorizationService } from "@/applications/services/auth/authorization.service.interface";
-import { ConflictError, UnexpectedError } from "@/entities/errors/app-error";
-import { CommonReason } from "@/entities/errors/reasons/common";
-import { PlayerReason } from "@/entities/errors/reasons/player";
+import {
+  ConflictError,
+  UnexpectedError,
+  CommonReason,
+  PlayerReason,
+} from "@/entities/errors";
 import type { Player } from "@/entities/player";
 import { PlayerRole, PlayerStatus } from "@/entities/player";
 import { TYPES } from "@/infrastructure/di/types";

--- a/src/applications/usecases/player/leave-team.usecase.ts
+++ b/src/applications/usecases/player/leave-team.usecase.ts
@@ -5,9 +5,9 @@ import {
   AuthorizationError,
   NotFoundError,
   UnexpectedError,
-} from "@/entities/errors/app-error";
-import { CommonReason } from "@/entities/errors/reasons/common";
-import { PlayerReason } from "@/entities/errors/reasons/player";
+  CommonReason,
+  PlayerReason,
+} from "@/entities/errors";
 import { PlayerRole, PlayerStatus } from "@/entities/player";
 import { TYPES } from "@/infrastructure/di/types";
 import { inject, injectable } from "inversify";

--- a/src/applications/usecases/player/reject-invitation.usecase.ts
+++ b/src/applications/usecases/player/reject-invitation.usecase.ts
@@ -1,6 +1,9 @@
 import type { IPlayerRepository } from "@/applications/repositories/player.repository.interface";
-import { AuthorizationError, NotFoundError } from "@/entities/errors/app-error";
-import { PlayerReason } from "@/entities/errors/reasons/player";
+import {
+  AuthorizationError,
+  NotFoundError,
+  PlayerReason,
+} from "@/entities/errors";
 import { PlayerStatus } from "@/entities/player";
 import { TYPES } from "@/infrastructure/di/types";
 import { inject, injectable } from "inversify";

--- a/src/applications/usecases/player/remove-player.usecase.ts
+++ b/src/applications/usecases/player/remove-player.usecase.ts
@@ -1,9 +1,12 @@
 import type { IPlayerRepository } from "@/applications/repositories/player.repository.interface";
 import type { ITeamRepository } from "@/applications/repositories/team.repository.interface";
 import type { IAuthorizationService } from "@/applications/services/auth/authorization.service.interface";
-import { NotFoundError, UnexpectedError } from "@/entities/errors/app-error";
-import { CommonReason } from "@/entities/errors/reasons/common";
-import { PlayerReason } from "@/entities/errors/reasons/player";
+import {
+  NotFoundError,
+  UnexpectedError,
+  CommonReason,
+  PlayerReason,
+} from "@/entities/errors";
 import { TYPES } from "@/infrastructure/di/types";
 import { inject, injectable } from "inversify";
 

--- a/src/applications/usecases/player/transfer-ownership.usecase.ts
+++ b/src/applications/usecases/player/transfer-ownership.usecase.ts
@@ -4,9 +4,9 @@ import {
   ConflictError,
   NotFoundError,
   UnexpectedError,
-} from "@/entities/errors/app-error";
-import { CommonReason } from "@/entities/errors/reasons/common";
-import { PlayerReason } from "@/entities/errors/reasons/player";
+  CommonReason,
+  PlayerReason,
+} from "@/entities/errors";
 import type { Player } from "@/entities/player";
 import { PlayerRole } from "@/entities/player";
 import { TYPES } from "@/infrastructure/di/types";

--- a/src/applications/usecases/player/update-player-info.usecase.ts
+++ b/src/applications/usecases/player/update-player-info.usecase.ts
@@ -1,8 +1,11 @@
 import type { IPlayerRepository } from "@/applications/repositories/player.repository.interface";
 import type { IAuthorizationService } from "@/applications/services/auth/authorization.service.interface";
-import { NotFoundError, UnexpectedError } from "@/entities/errors/app-error";
-import { CommonReason } from "@/entities/errors/reasons/common";
-import { PlayerReason } from "@/entities/errors/reasons/player";
+import {
+  NotFoundError,
+  UnexpectedError,
+  CommonReason,
+  PlayerReason,
+} from "@/entities/errors";
 import { type Player, type Position } from "@/entities/player";
 import { TYPES } from "@/infrastructure/di/types";
 import { inject, injectable } from "inversify";

--- a/src/applications/usecases/player/update-role.usecase.ts
+++ b/src/applications/usecases/player/update-role.usecase.ts
@@ -1,8 +1,11 @@
 import type { IPlayerRepository } from "@/applications/repositories/player.repository.interface";
 import type { IAuthorizationService } from "@/applications/services/auth/authorization.service.interface";
-import { NotFoundError, UnexpectedError } from "@/entities/errors/app-error";
-import { CommonReason } from "@/entities/errors/reasons/common";
-import { PlayerReason } from "@/entities/errors/reasons/player";
+import {
+  NotFoundError,
+  UnexpectedError,
+  CommonReason,
+  PlayerReason,
+} from "@/entities/errors";
 import type { Player, PlayerRole } from "@/entities/player";
 import { TYPES } from "@/infrastructure/di/types";
 import { inject, injectable } from "inversify";

--- a/src/applications/usecases/user/__tests__/search-user.usecase.test.ts
+++ b/src/applications/usecases/user/__tests__/search-user.usecase.test.ts
@@ -1,6 +1,6 @@
 import { createMockUserRepository, createUser } from "@/__tests__/helpers";
 import { SearchUserUseCase } from "@/applications/usecases/user/search-user.usecase";
-import { NotFoundError, ValidationError } from "@/entities/errors/app-error";
+import { NotFoundError, ValidationError } from "@/entities/errors";
 
 describe("SearchUserUseCase", () => {
   let useCase: SearchUserUseCase;

--- a/src/applications/usecases/user/get-user-by-id.usecase.ts
+++ b/src/applications/usecases/user/get-user-by-id.usecase.ts
@@ -1,7 +1,6 @@
 import type { IUserRepository } from "@/applications/repositories/user.repository.interface";
 import type { Result } from "@/applications/types/result";
-import { NotFoundError } from "@/entities/errors/app-error";
-import { CommonReason } from "@/entities/errors/reasons/common";
+import { NotFoundError, CommonReason } from "@/entities/errors";
 import type { User } from "@/entities/user";
 import { TYPES } from "@/infrastructure/di/types";
 import { inject, injectable } from "inversify";

--- a/src/applications/usecases/user/profile.usecase.ts
+++ b/src/applications/usecases/user/profile.usecase.ts
@@ -1,6 +1,5 @@
 import type { IProfileRepository } from "@/applications/repositories/profile.repository.interface";
-import { ValidationError } from "@/entities/errors/app-error";
-import { ProfileReason } from "@/entities/errors/reasons/profile";
+import { ValidationError, ProfileReason } from "@/entities/errors";
 import type { Profile } from "@/entities/profile";
 import { TYPES } from "@/infrastructure/di/types";
 import { inject, injectable } from "inversify";

--- a/src/applications/usecases/user/search-user.usecase.ts
+++ b/src/applications/usecases/user/search-user.usecase.ts
@@ -1,8 +1,11 @@
 import type { IUserRepository } from "@/applications/repositories/user.repository.interface";
 import type { Result } from "@/applications/types/result";
-import { NotFoundError, ValidationError } from "@/entities/errors/app-error";
-import { CommonReason } from "@/entities/errors/reasons/common";
-import { ProfileReason } from "@/entities/errors/reasons/profile";
+import {
+  NotFoundError,
+  ValidationError,
+  CommonReason,
+  ProfileReason,
+} from "@/entities/errors";
 import { TYPES } from "@/infrastructure/di/types";
 import { inject, injectable } from "inversify";
 

--- a/src/components/team/__tests__/alert-dialog-error-state.test.tsx
+++ b/src/components/team/__tests__/alert-dialog-error-state.test.tsx
@@ -3,7 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { MembershipSection } from "@/components/team/players/membership-section";
 import { createPlayer } from "@/__tests__/helpers";
 import { ApiClientError } from "@/lib/api/api-client";
-import type { AppErrorCode } from "@/entities/errors/app-error";
+import { type AppErrorCode } from "@/entities/errors";
 
 // Mock apiClient
 const mockApiClient = jest.fn();

--- a/src/components/team/__tests__/team-info-error-state.test.tsx
+++ b/src/components/team/__tests__/team-info-error-state.test.tsx
@@ -1,6 +1,6 @@
 import { createPlayer } from "@/__tests__/helpers";
 import TeamInfo from "@/components/team/info/index";
-import type { AppErrorCode } from "@/entities/errors/app-error";
+import { type AppErrorCode } from "@/entities/errors";
 import { ApiClientError } from "@/lib/api/api-client";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/src/entities/__tests__/errors/app-error.test.ts
+++ b/src/entities/__tests__/errors/app-error.test.ts
@@ -6,7 +6,7 @@ import {
   ConflictError,
   TransientError,
   UnexpectedError,
-} from "@/entities/errors/app-error";
+} from "@/entities/errors";
 
 describe("AppError class hierarchy", () => {
   describe("constructor with internalMessage", () => {

--- a/src/entities/__tests__/player.test.ts
+++ b/src/entities/__tests__/player.test.ts
@@ -1,4 +1,4 @@
-import { ValidationError } from "@/entities/errors/app-error";
+import { ValidationError } from "@/entities/errors";
 import {
   Player,
   PlayerRole,

--- a/src/entities/errors/index.ts
+++ b/src/entities/errors/index.ts
@@ -1,0 +1,17 @@
+export {
+  AppError,
+  AuthenticationError,
+  AuthorizationError,
+  ConflictError,
+  NotFoundError,
+  TransientError,
+  UnexpectedError,
+  ValidationError,
+  type AppErrorCode,
+} from "./app-error";
+
+export { AuthReason } from "./reasons/auth";
+export { CommonReason } from "./reasons/common";
+export { GameReason } from "./reasons/game";
+export { PlayerReason } from "./reasons/player";
+export { ProfileReason } from "./reasons/profile";

--- a/src/entities/player.ts
+++ b/src/entities/player.ts
@@ -14,8 +14,7 @@
  * - undefined: pure player without team and team role
  */
 
-import { ValidationError } from "@/entities/errors/app-error";
-import { CommonReason } from "@/entities/errors/reasons/common";
+import { ValidationError, CommonReason } from "@/entities/errors";
 
 export enum PlayerRole {
   MEMBER = "MEMBER",

--- a/src/infrastructure/db/repositories/__tests__/game.repository.test.ts
+++ b/src/infrastructure/db/repositories/__tests__/game.repository.test.ts
@@ -1,5 +1,5 @@
 import { mockDoc, mockExec } from "@/__tests__/helpers";
-import { NotFoundError } from "@/entities/errors/app-error";
+import { NotFoundError } from "@/entities/errors";
 import { EntryType, MoveType, Side, type Game } from "@/entities/game";
 import { Game as GameModel } from "@/infrastructure/db/mongoose/schemas/game";
 import { GameRepositoryImpl } from "@/infrastructure/db/repositories/game.repository.mongo";

--- a/src/infrastructure/db/repositories/__tests__/player.repository.test.ts
+++ b/src/infrastructure/db/repositories/__tests__/player.repository.test.ts
@@ -1,5 +1,5 @@
 import { createPlayer } from "@/__tests__/helpers";
-import { NotFoundError } from "@/entities/errors/app-error";
+import { NotFoundError } from "@/entities/errors";
 import { PlayerRole, PlayerStatus } from "@/entities/player";
 import { PlayerModel } from "@/infrastructure/db/mongoose/schemas/player";
 import { PlayerRepositoryImpl } from "@/infrastructure/db/repositories/player.repository.mongo";

--- a/src/infrastructure/db/repositories/__tests__/repository-helpers.test.ts
+++ b/src/infrastructure/db/repositories/__tests__/repository-helpers.test.ts
@@ -3,7 +3,7 @@ import {
   NotFoundError,
   TransientError,
   UnexpectedError,
-} from "@/entities/errors/app-error";
+} from "@/entities/errors";
 import { translateRepositoryError } from "@/infrastructure/db/repositories/repository-helpers.mongo";
 
 describe("Repository error translation", () => {

--- a/src/infrastructure/db/repositories/__tests__/team.repository.test.ts
+++ b/src/infrastructure/db/repositories/__tests__/team.repository.test.ts
@@ -1,5 +1,5 @@
 import { mockDoc, mockExec } from "@/__tests__/helpers";
-import { NotFoundError } from "@/entities/errors/app-error";
+import { NotFoundError } from "@/entities/errors";
 import { Position, type Lineup } from "@/entities/team";
 import { Team as TeamModel } from "@/infrastructure/db/mongoose/schemas/team";
 import { TeamRepositoryImpl } from "@/infrastructure/db/repositories/team.repository.mongo";

--- a/src/infrastructure/db/repositories/game.repository.mongo.ts
+++ b/src/infrastructure/db/repositories/game.repository.mongo.ts
@@ -1,6 +1,5 @@
 import type { IGameRepository } from "@/applications/repositories/game.repository.interface";
-import { NotFoundError } from "@/entities/errors/app-error";
-import { CommonReason } from "@/entities/errors/reasons/common";
+import { NotFoundError, CommonReason } from "@/entities/errors";
 import { EntryType, type Game, type GameSummary } from "@/entities/game";
 import {
   GameDocument,

--- a/src/infrastructure/db/repositories/player.repository.mongo.ts
+++ b/src/infrastructure/db/repositories/player.repository.mongo.ts
@@ -1,6 +1,5 @@
 import { IPlayerRepository } from "@/applications/repositories/player.repository.interface";
-import { NotFoundError } from "@/entities/errors/app-error";
-import { CommonReason } from "@/entities/errors/reasons/common";
+import { NotFoundError, CommonReason } from "@/entities/errors";
 import { Player, PlayerRole, PlayerStatus } from "@/entities/player";
 import {
   PlayerModel,

--- a/src/infrastructure/db/repositories/profile.repository.mongo.ts
+++ b/src/infrastructure/db/repositories/profile.repository.mongo.ts
@@ -1,6 +1,5 @@
 import type { IProfileRepository } from "@/applications/repositories/profile.repository.interface";
-import { NotFoundError } from "@/entities/errors/app-error";
-import { CommonReason } from "@/entities/errors/reasons/common";
+import { NotFoundError, CommonReason } from "@/entities/errors";
 import type { Profile } from "@/entities/profile";
 import {
   Profile as ProfileModel,

--- a/src/infrastructure/db/repositories/repository-helpers.mongo.ts
+++ b/src/infrastructure/db/repositories/repository-helpers.mongo.ts
@@ -4,8 +4,8 @@ import {
   NotFoundError,
   TransientError,
   UnexpectedError,
-} from "@/entities/errors/app-error";
-import { CommonReason } from "@/entities/errors/reasons/common";
+  CommonReason,
+} from "@/entities/errors";
 
 const NETWORK_ERROR_NAMES = new Set([
   "MongoNetworkError",

--- a/src/infrastructure/db/repositories/team.repository.mongo.ts
+++ b/src/infrastructure/db/repositories/team.repository.mongo.ts
@@ -1,6 +1,5 @@
 import { ITeamRepository } from "@/applications/repositories/team.repository.interface";
-import { NotFoundError } from "@/entities/errors/app-error";
-import { CommonReason } from "@/entities/errors/reasons/common";
+import { NotFoundError, CommonReason } from "@/entities/errors";
 import { Team, type Lineup, type LineupPlayer } from "@/entities/team";
 import {
   TeamDocument,

--- a/src/infrastructure/services/auth/__tests__/authentication.service.test.ts
+++ b/src/infrastructure/services/auth/__tests__/authentication.service.test.ts
@@ -1,5 +1,5 @@
 import { createMockUserRepository, createUser } from "@/__tests__/helpers";
-import { AuthenticationError } from "@/entities/errors/app-error";
+import { AuthenticationError } from "@/entities/errors";
 import { AuthenticationService } from "@/infrastructure/services/auth/authentication.service";
 
 jest.mock("@/lib/auth", () => ({

--- a/src/infrastructure/services/auth/__tests__/authorization.service.test.ts
+++ b/src/infrastructure/services/auth/__tests__/authorization.service.test.ts
@@ -1,5 +1,5 @@
 import { createMockPlayerRepository, createPlayer } from "@/__tests__/helpers";
-import { AuthorizationError } from "@/entities/errors/app-error";
+import { AuthorizationError } from "@/entities/errors";
 import { PlayerRole } from "@/entities/player";
 import { AuthorizationService } from "@/infrastructure/services/auth/authorization.service";
 

--- a/src/infrastructure/services/auth/authentication.service.ts
+++ b/src/infrastructure/services/auth/authentication.service.ts
@@ -1,7 +1,6 @@
 import type { IUserRepository } from "@/applications/repositories/user.repository.interface";
 import { IAuthenticationService } from "@/applications/services/auth/authentication.service.interface";
-import { AuthenticationError } from "@/entities/errors/app-error";
-import { AuthReason } from "@/entities/errors/reasons/auth";
+import { AuthenticationError, AuthReason } from "@/entities/errors";
 import { User } from "@/entities/user";
 import { TYPES } from "@/infrastructure/di/types";
 import { auth } from "@/lib/auth";

--- a/src/infrastructure/services/auth/authorization.service.ts
+++ b/src/infrastructure/services/auth/authorization.service.ts
@@ -1,8 +1,7 @@
 import type { IPlayerRepository } from "@/applications/repositories/player.repository.interface";
 import { IAuthorizationService } from "@/applications/services/auth/authorization.service.interface";
 import { PlayerRole } from "@/entities/player";
-import { AuthorizationError } from "@/entities/errors/app-error";
-import { AuthReason } from "@/entities/errors/reasons/auth";
+import { AuthorizationError, AuthReason } from "@/entities/errors";
 import { TYPES } from "@/infrastructure/di/types";
 import { inject, injectable } from "inversify";
 

--- a/src/interface/controllers/player/player.controller.ts
+++ b/src/interface/controllers/player/player.controller.ts
@@ -22,8 +22,7 @@ import type {
   IUpdatePlayerInfoInput,
   IUpdatePlayerInfoUseCase,
 } from "@/applications/usecases/player/update-player-info.usecase";
-import { NotFoundError } from "@/entities/errors/app-error";
-import { PlayerReason } from "@/entities/errors/reasons/player";
+import { NotFoundError, PlayerReason } from "@/entities/errors";
 import type { Player } from "@/entities/player";
 import { container } from "@/infrastructure/di/inversify.config";
 import { TYPES } from "@/infrastructure/di/types";

--- a/src/interface/controllers/user/profile.controller.ts
+++ b/src/interface/controllers/user/profile.controller.ts
@@ -11,8 +11,7 @@ import {
   type IUpdateProfileOutput,
 } from "@/applications/usecases/user/profile.usecase";
 import type { Profile } from "@/entities/profile";
-import { ValidationError } from "@/entities/errors/app-error";
-import { CommonReason } from "@/entities/errors/reasons/common";
+import { ValidationError, CommonReason } from "@/entities/errors";
 import { z } from "zod";
 
 // ============ Controller Layer Validation Schemas ============

--- a/src/lib/__tests__/auth-hook.test.ts
+++ b/src/lib/__tests__/auth-hook.test.ts
@@ -1,6 +1,5 @@
 import { createProfile } from "@/__tests__/helpers";
-import { TransientError } from "@/entities/errors/app-error";
-import { CommonReason } from "@/entities/errors/reasons/common";
+import { TransientError, CommonReason } from "@/entities/errors";
 import { handleUserCreated } from "@/lib/auth-hook";
 
 // Mock the DI container dependencies

--- a/src/lib/api/__tests__/guards.test.ts
+++ b/src/lib/api/__tests__/guards.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "@jest/globals";
-import { ValidationError } from "@/entities/errors/app-error";
-import { CommonReason } from "@/entities/errors/reasons/common";
+import { ValidationError, CommonReason } from "@/entities/errors";
 import { assertObjectId } from "@/lib/api/guards";
 
 describe("assertObjectId", () => {

--- a/src/lib/api/__tests__/wrappers.test.ts
+++ b/src/lib/api/__tests__/wrappers.test.ts
@@ -2,8 +2,8 @@ import {
   ConflictError,
   NotFoundError,
   ValidationError,
-} from "@/entities/errors/app-error";
-import { AuthReason } from "@/entities/errors/reasons/auth";
+  AuthReason,
+} from "@/entities/errors";
 import { withAuth, withErrorHandler } from "@/lib/api/wrappers";
 import { z } from "zod";
 

--- a/src/lib/api/guards.ts
+++ b/src/lib/api/guards.ts
@@ -1,5 +1,4 @@
-import { ValidationError } from "@/entities/errors/app-error";
-import { CommonReason } from "@/entities/errors/reasons/common";
+import { ValidationError, CommonReason } from "@/entities/errors";
 
 export const OBJECT_ID_RE = /^[0-9a-fA-F]{24}$/;
 

--- a/src/lib/api/parse-api-error.ts
+++ b/src/lib/api/parse-api-error.ts
@@ -1,4 +1,4 @@
-import type { AppErrorCode } from "@/entities/errors/app-error";
+import { type AppErrorCode } from "@/entities/errors";
 
 export interface ApiError {
   code: AppErrorCode;

--- a/src/lib/api/wrappers.ts
+++ b/src/lib/api/wrappers.ts
@@ -6,9 +6,9 @@ import {
   AuthenticationError,
   UnexpectedError,
   ValidationError,
-} from "@/entities/errors/app-error";
-import { AuthReason } from "@/entities/errors/reasons/auth";
-import { CommonReason } from "@/entities/errors/reasons/common";
+  AuthReason,
+  CommonReason,
+} from "@/entities/errors";
 import { auth } from "@/lib/auth";
 
 type RouteHandler = (req: NextRequest) => Promise<NextResponse>;

--- a/src/lib/auth-hook.ts
+++ b/src/lib/auth-hook.ts
@@ -1,6 +1,6 @@
 import type { ILinkPendingInvitationsUseCase } from "@/applications/usecases/user/link-pending-invitations.usecase";
 import type { CreateProfileUseCase } from "@/applications/usecases/user/profile.usecase";
-import { TransientError } from "@/entities/errors/app-error";
+import { TransientError } from "@/entities/errors";
 import { container } from "@/infrastructure/di/inversify.config";
 import { TYPES } from "@/infrastructure/di/types";
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,5 +1,5 @@
 import { getSessionCookie } from "better-auth/cookies";
-import { AuthReason } from "@/entities/errors/reasons/auth";
+import { AuthReason } from "@/entities/errors";
 import { auth } from "@/lib/auth";
 import {
   apiAuthPrefix,


### PR DESCRIPTION
## What

- Restores `src/entities/errors/index.ts` (deleted by the knip cleanup in PR #330), re-exporting `AppError` and its subclasses, `AppErrorCode`, and all reason enums (`AuthReason`, `CommonReason`, `GameReason`, `PlayerReason`, `ProfileReason`).
- Rewrites every consumer under `src/**` that imported from `@/entities/errors/app-error` or `@/entities/errors/reasons/*` to import from `@/entities/errors` instead, merging dual imports (app-error + one or more reasons modules) into a single statement per file where applicable.
- Relative imports within `src/entities/errors/` itself are untouched.

## Why

Decision reversed: the barrel reduces cognitive load by giving consumers a single import source for all error types, codes, and reasons instead of reaching into `app-error` and each `reasons/*` module separately. This partially reverts the barrel deletion from the knip cleanup while keeping the rest of that cleanup intact.

## Counts

- 70 files rewritten (+1 new barrel file)
- 119 import statements consolidated

## Verification

- `pnpm knip` — exit 0 (barrel is now referenced, not flagged as unused)
- `pnpm verify` (format, typecheck, lint, test) — exit 0, 98 test suites / 756 tests passed
- `MONGODB_URI="mongodb://localhost:27017/ci-placeholder" pnpm build` — exit 0

---

## 摘要（zh-tw）

還原先前被 knip 清理移除的 `src/entities/errors/index.ts` barrel 檔案，並將 `src/**` 下約 100 個檔案、119 個 import 陳述式改為統一從 `@/entities/errors` 匯入，減少認知負擔（單一來源匯入所有 error 類型與 reason）。已通過 `pnpm knip`、`pnpm verify`、`pnpm build` 驗證。
