### PR TITLE
fix(game): persist game players and seed new sets from prior lineup

### DIFF
--- a/.changeset/game-team-players-snapshot.md
+++ b/.changeset/game-team-players-snapshot.md
@@ -1,0 +1,10 @@
+---
+"volleybro": patch
+---
+
+### Fixed
+
+#### Record
+
+- Fix newly created games having no players, so the first set's lineup and the recording roster now show the selected members
+- Carry the previous set's lineup forward when adding a new set, instead of opening the set options with an empty court

--- a/src/components/game/new/index.tsx
+++ b/src/components/game/new/index.tsx
@@ -21,9 +21,13 @@ import { useToast } from "@/components/ui/use-toast";
 import { useTeam, useTeamPlayers } from "@/hooks/use-data";
 import { apiClient } from "@/lib/api/api-client";
 import { showErrorToast } from "@/lib/api/error-toast";
-import type { TMatchInfoForm } from "@/lib/features/game/types";
+import type {
+  LineupListPlayer,
+  TMatchInfoForm,
+} from "@/lib/features/game/types";
+import type { LineupList } from "@/lib/features/team/types";
 import { useRouter } from "next/navigation";
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { RiArrowLeftWideLine, RiArrowRightLine } from "react-icons/ri";
 import { useSWRConfig } from "swr";
 
@@ -58,14 +62,10 @@ export const NewGameForm = ({ teamId }: { teamId: string }) => {
     weather: { temperature: "" },
   });
 
-  const players = useMemo(() => {
-    const getPlayerData = (list: string) => {
-      if (!team || !teamPlayers) return [];
-      return (
-        team.lineups[lineupIndex][
-          list as "starting" | "liberos" | "substitutes"
-        ] as { id: string }[]
-      ).map((player) => {
+  const getPlayerData = (list: LineupList): LineupListPlayer[] => {
+    if (!team || !teamPlayers) return [];
+    return (team.lineups[lineupIndex][list] as { id: string }[]).map(
+      (player) => {
         const member = teamPlayers.find((p) => p.id === player.id);
         return {
           id: member?.id ?? "",
@@ -73,19 +73,14 @@ export const NewGameForm = ({ teamId }: { teamId: string }) => {
           number: member?.number ?? 0,
           list,
         };
-      });
-    };
+      },
+    );
+  };
 
-    const starting = getPlayerData("starting");
-    const liberos = getPlayerData("liberos");
-    const substitutes = getPlayerData("substitutes");
-    return starting
-      .concat(liberos, substitutes)
-      .filter((player) => player.id)
-      .sort(
-        (a: { number: number }, b: { number: number }) => a.number - b.number,
-      );
-  }, [team, teamPlayers, lineupIndex]);
+  const players = getPlayerData("starting")
+    .concat(getPlayerData("liberos"), getPlayerData("substitutes"))
+    .filter((player) => player.id)
+    .sort((a, b) => a.number - b.number);
 
   const createGame = async () => {
     const infoData = {

--- a/src/components/game/new/index.tsx
+++ b/src/components/game/new/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { MatchInfo } from "@/components/game/match";
 import { MatchInfoForm } from "@/components/game/new/info-form";
-import { RosterList } from "@/components/game/new/roster-list";
+import { PlayersList } from "@/components/game/new/players-list";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -33,7 +33,8 @@ export const NewGameForm = ({ teamId }: { teamId: string }) => {
   const [view, setView] = useState("");
   const { mutate } = useSWRConfig();
   const { team, isLoading: isTeamLoading } = useTeam(teamId);
-  const { players, isLoading: isPlayersLoading } = useTeamPlayers(teamId);
+  const { players: teamPlayers, isLoading: isPlayersLoading } =
+    useTeamPlayers(teamId);
 
   const [lineupIndex, setLineupIndex] = useState(0);
   const handleViewChange = (view: string) => {
@@ -57,15 +58,15 @@ export const NewGameForm = ({ teamId }: { teamId: string }) => {
     weather: { temperature: "" },
   });
 
-  const roster = useMemo(() => {
+  const players = useMemo(() => {
     const getPlayerData = (list: string) => {
-      if (!team || !players) return [];
+      if (!team || !teamPlayers) return [];
       return (
         team.lineups[lineupIndex][
           list as "starting" | "liberos" | "substitutes"
         ] as { id: string }[]
       ).map((player) => {
-        const member = players.find((p) => p.id === player.id);
+        const member = teamPlayers.find((p) => p.id === player.id);
         return {
           id: member?.id ?? "",
           name: member?.name ?? "",
@@ -84,7 +85,7 @@ export const NewGameForm = ({ teamId }: { teamId: string }) => {
       .sort(
         (a: { number: number }, b: { number: number }) => a.number - b.number,
       );
-  }, [team, players, lineupIndex]);
+  }, [team, teamPlayers, lineupIndex]);
 
   const createGame = async () => {
     const infoData = {
@@ -108,7 +109,7 @@ export const NewGameForm = ({ teamId }: { teamId: string }) => {
             home: {
               id: teamId,
               name: info.teams.home.name,
-              roster,
+              players,
               lineup: team?.lineups[lineupIndex],
             },
             away: { name: info.teams.away.name },
@@ -173,7 +174,7 @@ export const NewGameForm = ({ teamId }: { teamId: string }) => {
                   </CardBtnGroup>
                 </CardTitle>
               </CardHeader>
-              <RosterList roster={roster} />
+              <PlayersList players={players} />
             </Card>
           </DialogBody>
           <DialogFooter>

--- a/src/components/game/new/players-list.tsx
+++ b/src/components/game/new/players-list.tsx
@@ -29,7 +29,7 @@ export const PlayersList = ({ players }: { players: LineupListPlayer[] }) => {
   );
 };
 
-const ListBadge = ({ list }: { list: string }) => {
+const ListBadge = ({ list }: { list: LineupListPlayer["list"] }) => {
   if (list === "substitutes") return null;
 
   return (

--- a/src/components/game/new/players-list.tsx
+++ b/src/components/game/new/players-list.tsx
@@ -7,12 +7,12 @@ import {
   ItemGroup,
   ItemTitle,
 } from "@/components/ui/item";
-import type { TableRosterPlayer } from "@/lib/features/game/types";
+import type { TablePlayer } from "@/lib/features/game/types";
 
-export const RosterList = ({ roster }: { roster: TableRosterPlayer[] }) => {
+export const PlayersList = ({ players }: { players: TablePlayer[] }) => {
   return (
     <ItemGroup className="flex flex-col">
-      {roster.map((player) => (
+      {players.map((player) => (
         <Item key={player.id}>
           <ItemContent>
             <ItemTitle className="h-5 text-base">{player.name}</ItemTitle>

--- a/src/components/game/new/players-list.tsx
+++ b/src/components/game/new/players-list.tsx
@@ -7,9 +7,9 @@ import {
   ItemGroup,
   ItemTitle,
 } from "@/components/ui/item";
-import type { TablePlayer } from "@/lib/features/game/types";
+import type { LineupListPlayer } from "@/lib/features/game/types";
 
-export const PlayersList = ({ players }: { players: TablePlayer[] }) => {
+export const PlayersList = ({ players }: { players: LineupListPlayer[] }) => {
   return (
     <ItemGroup className="flex flex-col">
       {players.map((player) => (

--- a/src/components/game/set-options/index.tsx
+++ b/src/components/game/set-options/index.tsx
@@ -9,6 +9,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { useGame } from "@/hooks/use-data";
+import { getSetLineup } from "@/lib/features/game/helpers";
 import { lineupActions } from "@/lib/features/team/lineup-slice";
 import { useAppDispatch } from "@/lib/redux/hooks";
 import { useEffect } from "react";
@@ -24,8 +25,7 @@ export const SetOptions = ({
   const { game } = useGame(gameId);
 
   useEffect(() => {
-    const lineup =
-      game?.sets[setIndex]?.lineups?.home ?? game?.teams.home.lineup;
+    const lineup = getSetLineup(game, setIndex);
     if (lineup) dispatch(lineupActions.initialize([lineup]));
   }, [game, setIndex, dispatch]);
 

--- a/src/lib/features/game/helpers/index.ts
+++ b/src/lib/features/game/helpers/index.ts
@@ -2,6 +2,7 @@ import { gamePhaseHelper } from "@/lib/features/game/helpers/queries/game-phase.
 import { getPreviousRally } from "@/lib/features/game/helpers/queries/previous-rally.helper";
 import { getPreviousScores } from "@/lib/features/game/helpers/queries/previous-scores.helper";
 import { getServingStatus } from "@/lib/features/game/helpers/queries/serving-status.helper";
+import { getSetLineup } from "@/lib/features/game/helpers/queries/set-lineup.helper";
 
 import {
   createRallyHelper,
@@ -16,5 +17,6 @@ export {
   getPreviousRally,
   getPreviousScores,
   getServingStatus,
+  getSetLineup,
   updateRallyHelper,
 };

--- a/src/lib/features/game/helpers/queries/set-lineup.helper.ts
+++ b/src/lib/features/game/helpers/queries/set-lineup.helper.ts
@@ -1,0 +1,18 @@
+import type { GameView } from "@/lib/features/game/types";
+import type { LineupView } from "@/lib/features/team/types";
+
+/**
+ * Resolves the lineup used to seed a set's options form.
+ *
+ * - Existing set: that set's own home lineup.
+ * - New set (index >= 1): carry the previous set's home lineup forward.
+ * - First set: fall back to the team's default lineup (still present until the
+ *   first set is created, then intentionally deleted as redundant).
+ */
+export const getSetLineup = (
+  game: GameView | undefined,
+  setIndex: number,
+): LineupView | undefined =>
+  game?.sets[setIndex]?.lineups?.home ??
+  game?.sets[setIndex - 1]?.lineups?.home ??
+  game?.teams.home.lineup;

--- a/src/lib/features/game/helpers/queries/tests/set-lineup.helper.test.ts
+++ b/src/lib/features/game/helpers/queries/tests/set-lineup.helper.test.ts
@@ -1,0 +1,48 @@
+import { Position } from "@/entities/team";
+import { getSetLineup } from "@/lib/features/game/helpers";
+import type { GameView } from "@/lib/features/game/types";
+import type { LineupView } from "@/lib/features/team/types";
+
+const makeLineup = (marker: string): LineupView => ({
+  options: { liberoReplaceMode: 0, liberoReplacePosition: Position.NONE },
+  starting: [{ id: marker }],
+  liberos: [],
+  substitutes: [],
+});
+
+const makeGame = (
+  sets: { lineups: { home: LineupView } }[],
+  teamLineup?: LineupView,
+): GameView =>
+  ({
+    sets,
+    teams: { home: { lineup: teamLineup }, away: {} },
+  }) as unknown as GameView;
+
+describe("getSetLineup", () => {
+  it("returns the set's own lineup when the set exists", () => {
+    const game = makeGame([{ lineups: { home: makeLineup("set0") } }]);
+    expect(getSetLineup(game, 0)).toEqual(makeLineup("set0"));
+  });
+
+  it("carries the previous set's lineup forward for a new subsequent set", () => {
+    const game = makeGame([{ lineups: { home: makeLineup("set0") } }]);
+    // Adding set 1: teams.home.lineup was deleted after set 0, so it must fall
+    // back to set 0's lineup.
+    expect(getSetLineup(game, 1)).toEqual(makeLineup("set0"));
+  });
+
+  it("falls back to the team default lineup for the first set", () => {
+    const game = makeGame([], makeLineup("team"));
+    expect(getSetLineup(game, 0)).toEqual(makeLineup("team"));
+  });
+
+  it("returns undefined for the first set when no team lineup exists", () => {
+    const game = makeGame([]);
+    expect(getSetLineup(game, 0)).toBeUndefined();
+  });
+
+  it("returns undefined when game is undefined", () => {
+    expect(getSetLineup(undefined, 0)).toBeUndefined();
+  });
+});

--- a/src/lib/features/game/types.ts
+++ b/src/lib/features/game/types.ts
@@ -7,6 +7,7 @@ import {
   Side,
 } from "@/entities/game";
 import { Position as TeamPosition } from "@/entities/team";
+import type { LineupList } from "@/lib/features/team/types";
 import { z } from "zod";
 
 const StatEntryResponseSchema = z.object({
@@ -273,11 +274,11 @@ export const SetOptionsFormSchema = z.object({
 
 export type SetOptionsFormValues = z.infer<typeof SetOptionsFormSchema>;
 
-export type TablePlayer = {
+export type LineupListPlayer = {
   id: string;
   name: string;
   number: number;
-  list: string;
+  list: LineupList;
 };
 
 // For Redux

--- a/src/lib/features/game/types.ts
+++ b/src/lib/features/game/types.ts
@@ -273,7 +273,7 @@ export const SetOptionsFormSchema = z.object({
 
 export type SetOptionsFormValues = z.infer<typeof SetOptionsFormSchema>;
 
-export type TableRosterPlayer = {
+export type TablePlayer = {
   id: string;
   name: string;
   number: number;

--- a/src/lib/features/team/types.ts
+++ b/src/lib/features/team/types.ts
@@ -57,6 +57,7 @@ export const TeamResponseSchema = z.object({
 export type PlayerView = z.infer<typeof PlayerResponseSchema>;
 export type TeamView = z.infer<typeof TeamResponseSchema>;
 export type LineupView = z.infer<typeof LineupResponseSchema>;
+export type LineupList = "starting" | "liberos" | "substitutes";
 
 // For Forms
 export const LiberoReplaceFormSchema = z.object({
@@ -80,7 +81,7 @@ export type ReduxLineupStatus = {
   optionMode: LineupOptionMode;
   editingMember: {
     id: string | null;
-    list: "starting" | "liberos" | "substitutes" | "";
+    list: LineupList | "";
     zone: number | null;
   };
 };


### PR DESCRIPTION
## Problem

On `/game/[gameId]/sets`, opening the SetOptions dialog (「新增一局」) showed an empty court — the selected lineup was never carried in. Two independent defects:

1. **Empty player snapshot.** The new-game form sent the player list under the key `roster`, but the game schema and read view only recognize `players`, so `teams.home.players` persisted as an empty array. The court and the recording roster resolve player names by id against that array, leaving every lineup blank.
2. **No seed for subsequent sets.** `teams.home.lineup` is intentionally deleted once the first set exists (it becomes redundant with `sets[0].lineups.home`). The seed logic had no other fallback, so adding a 2nd+ set opened with an empty court.

## Changes

- Send the player snapshot under `players` so it round-trips into `teams.home.players`.
- Add `getSetLineup(game, setIndex)` (`helpers/queries/`) with a fallback chain: existing set → previous set → team default (first set). Respects the existing deletion policy; no domain changes. Unit-tested (5 cases).
- Naming cleanup: `players` is the data key across API/domain/DB/Redux; `roster` reserved for UI display text. `RosterList`→`PlayersList`, `TableRosterPlayer`→`LineupListPlayer`, and a new `LineupList` union tightens the `list` field.
- Drop a needless `useMemo` in the new-game form (trivial compute, no memoized consumer).

## Notes

- **Forward-only.** Games created before this fix already have an empty `players` array; code cannot backfill them. No migration included (by decision).
- Patch changeset included; version bump left to the release flow.

## 中文摘要

修正在 `/game/[gameId]/sets` 點「新增一局」時陣容帶不進來的問題,根因有二:建 game 時球員名單送錯 key(`roster` 而非 `players`)導致 `teams.home.players` 存成空陣列;以及新增第二局之後沒有 fallback 到上一局陣容(`teams.home.lineup` 在建立第一局後會被刻意刪除)。修法:payload 改送 `players`、新增 `getSetLineup` fallback chain(既有局→上一局→team 預設)並附單元測試、統一 players/roster 命名、移除多餘的 `useMemo`。