### PR TITLE
fix(pwa): version apple-splash URLs so the redesigned launch screen updates

### DIFF
--- a/.changeset/apple-splash-cache-bust.md
+++ b/.changeset/apple-splash-cache-bust.md
@@ -1,0 +1,9 @@
+---
+"volleybro": patch
+---
+
+### Fixed
+
+#### Brand
+
+- Fix the iOS PWA launch screen still showing the previous centered-symbol logo — the apple-splash image URLs are now version-busted, so the redesigned splash (new mark centered with the wordmark at the bottom) is fetched instead of the cached old one

--- a/src/app/apple-splash/devices.ts
+++ b/src/app/apple-splash/devices.ts
@@ -4,6 +4,13 @@ export type DeviceConfig = {
   height: number;
 };
 
+// The apple-splash route serves images as `immutable`, so a design change at
+// the same URL is never re-fetched by CDN / service worker / browser. Bump this
+// whenever the splash rendering changes to move the URL and bust those caches.
+// (iOS home-screen installs still cache the splash at install time — those need
+// a remove-and-re-add; this only fixes the HTTP-cache layers.)
+export const SPLASH_VERSION = "2";
+
 export const devices: DeviceConfig[] = [
   // iPhone (existing 9)
   {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,7 +6,7 @@ import { Toaster } from "@/components/ui/toaster";
 import { ReduxProvider } from "@/lib/redux/provider";
 import { Analytics } from "@vercel/analytics/react";
 import { SpeedInsights } from "@vercel/speed-insights/next";
-import { devices } from "@/app/apple-splash/devices";
+import { devices, SPLASH_VERSION } from "@/app/apple-splash/devices";
 import type { Metadata, Viewport } from "next";
 import { Noto_Sans_TC, Saira } from "next/font/google";
 
@@ -40,7 +40,7 @@ export const metadata: Metadata = {
     statusBarStyle: "black-translucent",
     title: APP_DEFAULT_TITLE,
     startupImage: devices.map(({ media, width, height }) => ({
-      url: `/apple-splash/${width}x${height}`,
+      url: `/apple-splash/${width}x${height}?v=${SPLASH_VERSION}`,
       media,
     })),
   },


### PR DESCRIPTION
Delivers the v0.14.3 patch.

## Problem

The iOS PWA launch screen still shows the pre-redesign splash (centered symbol only) instead of the `logo-v-splash-redesign` version (new mark centered + wordmark at the bottom). The `/apple-splash/{w}x{h}` route serves images with `Cache-Control: public, max-age=31536000, immutable` at a **stable, unversioned URL**, so when the rendering changed the URL did not — CDN, service worker, and browser caches keep serving the old immutable image.

## Fix

Append `?v=<SPLASH_VERSION>` to the startup-image URLs (`SPLASH_VERSION` in `apple-splash/devices.ts`) and bump it, moving the URL so those caches miss and fetch the new image. `immutable` stays — correct once URLs are versioned. Bump `SPLASH_VERSION` on any future splash change.

## Scope note

This is the only asset in the repo served `immutable` at a stable URL (the app shell is already build-hashed + SW-managed; public/ icons + manifest revalidate). iOS **home-screen installs** cache the splash at install and still need a remove-and-re-add — this fixes the HTTP-cache layers for new/refreshed loads.

## 中文摘要

修正 iOS PWA 啟動畫面仍顯示改版前 splash 的問題:`/apple-splash` 路由以 `immutable` 一年快取供圖但 URL 未版本化,設計改了 URL 沒變 → CDN/SW/瀏覽器續供舊圖。修法:startup-image URL 加 `?v=<SPLASH_VERSION>` 並 bump,換 URL 破快取(保留 immutable)。全專案唯一 immutable stable-URL 資產即此路由。已安裝的 iOS 主畫面需移除重加才會更新(iOS 限制)。