### PR TITLE
chore: sync v0.14.3 release back to dev [skip review]

### DIFF
--- a/.changeset/apple-splash-cache-bust.md
+++ b/.changeset/apple-splash-cache-bust.md
@@ -1,9 +1,0 @@
----
-"volleybro": patch
----
-
-### Fixed
-
-#### Brand
-
-- Fix the iOS PWA launch screen still showing the previous centered-symbol logo — the apple-splash image URLs are now version-busted, so the redesigned splash (new mark centered with the wordmark at the bottom) is fetched instead of the cached old one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # VolleyBro CHANGELOG
 
+## [0.14.3](https://github.com/andrewck24/volleybro/compare/v0.14.2...v0.14.3) 2026-07-23
+
+### Fixed
+
+#### Brand
+
+- Fix the iOS PWA launch screen still showing the previous centered-symbol logo — the apple-splash image URLs are now version-busted, so the redesigned splash (new mark centered with the wordmark at the bottom) is fetched instead of the cached old one
+
 ## [0.14.2](https://github.com/andrewck24/volleybro/compare/v0.14.1...v0.14.2) 2026-07-23
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "volleybro",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@11.1.3",


### PR DESCRIPTION
Automated sync of the v0.14.3 release commit (version bump, CHANGELOG entry, consumed changeset deletions) from main back into dev.