### PR TITLE
fix(game): guard Entry against undefined entry to prevent recording crash

### DIFF
--- a/src/components/game/__tests__/preview.test.tsx
+++ b/src/components/game/__tests__/preview.test.tsx
@@ -37,9 +37,17 @@ const mockGame = {
   ],
 };
 
+// Mutable override so a single test can swap in a different game (e.g. the
+// empty-entries case) without disturbing the shared mockGame the rest use.
+let mockGameOverride: typeof mockGame | null = null;
+
 jest.mock("@/hooks/use-data", () => ({
-  useGame: () => ({ game: mockGame, mutate: jest.fn() }),
+  useGame: () => ({ game: mockGameOverride ?? mockGame, mutate: jest.fn() }),
 }));
+
+afterEach(() => {
+  mockGameOverride = null;
+});
 
 const SEND_LABEL = "送出";
 
@@ -121,6 +129,37 @@ describe("GamePreview submission", () => {
 
 // D8/D12 "Gesture split while input is in progress": idle taps expand the
 // drawer, in-progress taps only ever submit (never expand), complete or not.
+// Regression (ATE-91): at entryIndex 0 with an empty draft the derived entry is
+// undefined (both draftEntry and entries[-1] resolve to undefined). The hook
+// must report "not in progress" so GamePreview renders nothing instead of
+// handing an undefined entry to <Entry> and white-screening the Game tree.
+describe("GamePreview empty-entries guard", () => {
+  it("renders nothing when the entry would be undefined (entryIndex 0, no draft)", () => {
+    mockGameOverride = {
+      ...mockGame,
+      sets: [{ entries: [], options: { serve: "home" } }],
+    } as unknown as typeof mockGame;
+    const store = makeStore();
+    act(() => {
+      store.dispatch(
+        gameActions.initialize({
+          game: mockGameOverride as never,
+          setIndex: 0,
+        }),
+      );
+    });
+
+    render(
+      <Provider store={store}>
+        <GamePreview gameId="game-1" mode="general" />
+      </Provider>,
+    );
+
+    expect(screen.queryByTestId("preview-card")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("preview-trigger")).not.toBeInTheDocument();
+  });
+});
+
 describe("GamePreview gesture split", () => {
   it("expands the drawer on tap while idle (no draft in progress)", async () => {
     const user = userEvent.setup();

--- a/src/components/game/__tests__/preview.test.tsx
+++ b/src/components/game/__tests__/preview.test.tsx
@@ -127,12 +127,9 @@ describe("GamePreview submission", () => {
   });
 });
 
-// D8/D12 "Gesture split while input is in progress": idle taps expand the
-// drawer, in-progress taps only ever submit (never expand), complete or not.
-// Regression (ATE-91): at entryIndex 0 with an empty draft the derived entry is
-// undefined (both draftEntry and entries[-1] resolve to undefined). The hook
-// must report "not in progress" so GamePreview renders nothing instead of
-// handing an undefined entry to <Entry> and white-screening the Game tree.
+// At entryIndex 0 with an empty draft there is no entry to preview (no draft
+// and no prior entry), so the hook reports "not in progress" and GamePreview
+// renders nothing instead of handing an undefined entry to <Entry>.
 describe("GamePreview empty-entries guard", () => {
   it("renders nothing when the entry would be undefined (entryIndex 0, no draft)", () => {
     mockGameOverride = {
@@ -157,6 +154,46 @@ describe("GamePreview empty-entries guard", () => {
 
     expect(screen.queryByTestId("preview-card")).not.toBeInTheDocument();
     expect(screen.queryByTestId("preview-trigger")).not.toBeInTheDocument();
+  });
+
+  // End-to-end crash path: with no committed entries, freezing a complete draft
+  // on submit leaves `previousEntry` undefined. Freezing must fall back to the
+  // draft entry itself (previousEntry ?? entry) rather than feed undefined to
+  // <Entry> and white-screen the Game tree.
+  it("does not throw when freezing the first entry (no previous entry)", async () => {
+    mockGameOverride = {
+      ...mockGame,
+      sets: [{ entries: [], options: { serve: "home" } }],
+    } as unknown as typeof mockGame;
+    const user = userEvent.setup();
+    const store = makeStore();
+    act(() => {
+      store.dispatch(
+        gameActions.initialize({
+          game: mockGameOverride as never,
+          setIndex: 0,
+        }),
+      );
+      store.dispatch(gameActions.setEntryDraftPlayer({ id: "p2", zone: 1 }));
+      store.dispatch(gameActions.setEntryDraftHomeMove(scoringMoves[3]));
+    });
+
+    const onSubmit = jest.fn();
+    render(
+      <Provider store={store}>
+        <GamePreview gameId="game-1" mode="general" onSubmit={onSubmit} />
+      </Provider>,
+    );
+
+    await user.click(screen.getByTestId("preview-trigger"));
+
+    // Submission fired and the frozen card still renders the draft entry (#7)
+    // instead of crashing on an undefined previous entry.
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("7")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("img", { name: SEND_LABEL }),
+    ).not.toBeInTheDocument();
   });
 });
 

--- a/src/components/game/entry/__tests__/entry-row.test.tsx
+++ b/src/components/game/entry/__tests__/entry-row.test.tsx
@@ -1,4 +1,4 @@
-import { EntryRow } from "@/components/game/entry";
+import { Entry, EntryRow } from "@/components/game/entry";
 import { EntryType, MoveType } from "@/entities/game";
 import type { EntryView, GamePlayerView } from "@/lib/features/game/types";
 import { fireEvent, render, screen } from "@testing-library/react";
@@ -24,6 +24,19 @@ const entry: EntryView = {
 // event type name instead, mirroring panel/progress-bar.test.tsx.
 const pointerEvent = (type: string, clientX: number) =>
   new MouseEvent(type, { bubbles: true, cancelable: true, clientX });
+
+describe("Entry", () => {
+  // Regression (ATE-91): an undefined entry can reach <Entry> via the recording
+  // Preview (entryIndex 0 -> previousEntry === entries[-1]) or an optimistic
+  // rollback. It must render nothing rather than dereference `.type` and crash.
+  it("renders nothing without throwing when entry is undefined", () => {
+    const { container } = render(
+      <Entry entry={undefined as unknown as EntryView} players={[]} />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});
 
 describe("EntryRow", () => {
   it("is collapsed and unrevealed by default", () => {

--- a/src/components/game/entry/__tests__/entry-row.test.tsx
+++ b/src/components/game/entry/__tests__/entry-row.test.tsx
@@ -26,13 +26,10 @@ const pointerEvent = (type: string, clientX: number) =>
   new MouseEvent(type, { bubbles: true, cancelable: true, clientX });
 
 describe("Entry", () => {
-  // Regression (ATE-91): an undefined entry can reach <Entry> via the recording
-  // Preview (entryIndex 0 -> previousEntry === entries[-1]) or an optimistic
-  // rollback. It must render nothing rather than dereference `.type` and crash.
+  // An undefined entry can reach <Entry> via the recording Preview or an
+  // optimistic rollback; it must render nothing rather than dereference `.type`.
   it("renders nothing without throwing when entry is undefined", () => {
-    const { container } = render(
-      <Entry entry={undefined as unknown as EntryView} players={[]} />,
-    );
+    const { container } = render(<Entry entry={undefined} players={[]} />);
 
     expect(container).toBeEmptyDOMElement();
   });

--- a/src/components/game/entry/index.tsx
+++ b/src/components/game/entry/index.tsx
@@ -24,6 +24,12 @@ export const Entry = ({
   onClick?: () => void;
   className?: string;
 }) => {
+  // Shared guard for every caller (Preview, summary-drawer rows, etc.): a
+  // nullish or type-less entry can reach here via the recording Preview
+  // (entryIndex 0 -> previousEntry === entries[-1]) or an optimistic-mutate
+  // rollback. Render nothing rather than dereferencing `.type` and crashing.
+  if (!entry?.type) return null;
+
   return (
     <EntryContainer onClick={onClick} className={className}>
       {entry.type === EntryType.RALLY ? (

--- a/src/components/game/entry/index.tsx
+++ b/src/components/game/entry/index.tsx
@@ -19,15 +19,11 @@ export const Entry = ({
   onClick,
   className,
 }: {
-  entry: EntryView;
+  entry?: EntryView;
   players: GamePlayerView[];
   onClick?: () => void;
   className?: string;
 }) => {
-  // Shared guard for every caller (Preview, summary-drawer rows, etc.): a
-  // nullish or type-less entry can reach here via the recording Preview
-  // (entryIndex 0 -> previousEntry === entries[-1]) or an optimistic-mutate
-  // rollback. Render nothing rather than dereferencing `.type` and crashing.
   if (!entry?.type) return null;
 
   return (

--- a/src/components/game/preview.tsx
+++ b/src/components/game/preview.tsx
@@ -34,8 +34,8 @@ export const PreviewCard = ({
   onExpand,
   className,
 }: {
-  entry: EntryView;
-  previousEntry: EntryView;
+  entry?: EntryView;
+  previousEntry?: EntryView;
   players: GamePlayerView[];
   isEditing?: boolean;
   isPulsing?: boolean;
@@ -63,7 +63,7 @@ export const PreviewCard = ({
     if (!isEditing) onExpand?.();
   };
 
-  const shownEntry = frozen ? previousEntry : entry;
+  const shownEntry = frozen ? (previousEntry ?? entry) : entry;
   const showSendAffordance = Boolean(isEditing && isComplete && !frozen);
 
   return (
@@ -128,7 +128,8 @@ export const useEntryDraftPreview = (
   if (!game || !inProgress) return { inProgress: false as const };
 
   const { players } = game.teams.home;
-  const lastEntry = game.sets[setIndex].entries[entryIndex - 1];
+  const previousEntry =
+    entryIndex > 0 ? game.sets[setIndex].entries[entryIndex - 1] : undefined;
   const isEditing = Boolean(draft.home.player?.id) || Boolean(draft.home.type);
 
   const draftRallyEntry = isEditing
@@ -156,27 +157,23 @@ export const useEntryDraftPreview = (
       ? { type: EntryType.TIMEOUT, ...draft.timeout }
       : draft.challenge
         ? { type: EntryType.CHALLENGE, ...draft.challenge }
-        : (draftRallyEntry ?? lastEntry);
+        : (draftRallyEntry ?? previousEntry);
 
-  const entry = isEditing || entryIndex === 0 ? draftEntry : lastEntry;
+  const entry = isEditing || entryIndex === 0 ? draftEntry : previousEntry;
 
-  // Never surface an in-progress state with an undefined entry: at entryIndex 0
-  // with no draft yet, both draftEntry and lastEntry (entries[-1]) are
-  // undefined, which would render a broken Preview card. Degrade to "not in
-  // progress" so consumers render nothing.
+  // No draft and no prior entry (the first entry, before any input): nothing to
+  // preview.
   if (!entry) return { inProgress: false as const };
 
-  // Fail safe: derive completeness from getEntryProgress (reused from task
-  // group 1, do not duplicate) and check the boolean explicitly so a
-  // partially-complete draft never shows the send affordance -- guards
-  // against falsy-but-valid values (e.g. num === 0) or type confusion.
+  // Explicit boolean check so a falsy-but-valid draft value (e.g. num === 0)
+  // never trips the send affordance.
   const { submittable } = getEntryProgress(draft);
   const isComplete = submittable === true;
 
   return {
     inProgress: true as const,
     entry,
-    previousEntry: lastEntry,
+    previousEntry,
     players,
     isEditing,
     isComplete,

--- a/src/components/game/preview.tsx
+++ b/src/components/game/preview.tsx
@@ -160,6 +160,12 @@ export const useEntryDraftPreview = (
 
   const entry = isEditing || entryIndex === 0 ? draftEntry : lastEntry;
 
+  // Never surface an in-progress state with an undefined entry: at entryIndex 0
+  // with no draft yet, both draftEntry and lastEntry (entries[-1]) are
+  // undefined, which would render a broken Preview card. Degrade to "not in
+  // progress" so consumers render nothing.
+  if (!entry) return { inProgress: false as const };
+
   // Fail safe: derive completeness from getEntryProgress (reused from task
   // group 1, do not duplicate) and check the boolean explicitly so a
   // partially-complete draft never shows the send affordance -- guards

--- a/src/components/game/summary-drawer.tsx
+++ b/src/components/game/summary-drawer.tsx
@@ -16,7 +16,7 @@ export type SummaryDrawerState = "idle" | "expanded";
 /** Props PreviewCard needs, minus `inProgress` (the caller already checked it). */
 export type SummaryDrawerPreview = {
   entry: EntryView;
-  previousEntry: EntryView;
+  previousEntry: EntryView | undefined;
   players: GamePlayerView[];
   isEditing: boolean;
   isComplete: boolean;


### PR DESCRIPTION
## Summary

Submitting a rally could white-screen the entire Game tree with `Runtime TypeError: Cannot read properties of undefined (reading 'type')` at `Entry` (`src/components/game/entry/index.tsx`).

Root cause: in the recording Preview, at `entryIndex === 0` the card freezes on submit and demotes the draft to `previousEntry`, which resolves to `entries[-1]` — `undefined`. `<Entry>` then dereferenced `entry.type` and threw. The same undefined entry can also arise after an optimistic-mutate rollback. Both `GamePreview` and the Summary drawer's `PreviewCard` hit this path.

## Changes

- `src/components/game/entry/index.tsx` — `<Entry>` returns `null` for a nullish or type-less `entry`. This is the single shared guard protecting every caller (Preview, summary-drawer rows, etc.).
- `src/components/game/preview.tsx` — `useEntryDraftPreview` reports `{ inProgress: false }` when the resolved `entry` would be `undefined`, so consumers render nothing rather than a broken card.
- Regression tests: `<Entry entry={undefined}>` renders nothing without throwing; `useEntryDraftPreview`/`GamePreview` renders nothing for the empty-entries / `entryIndex 0` case.

## Verification

`pnpm verify` passes: format, typecheck, lint, and 770 tests across 100 suites.

Refs ATE-91.

---

## 摘要（zh-tw）

送出一次 rally 時，整個 Game 元件樹會白屏崩潰。根因是錄製 Preview 在 `entryIndex 0` 送出後會 freeze 並將草稿降級為 `previousEntry`，此時 `previousEntry` 解析為 `entries[-1]`（`undefined`），`<Entry>` 讀取 `entry.type` 便拋錯；樂觀更新回滾也會產生相同的 undefined。修正方式是在共用的收斂點加上防護：`<Entry>` 對 nullish／無 `type` 的 entry 直接 render `null`，而 `useEntryDraftPreview` 在解析出的 entry 為 undefined 時回傳 `inProgress: false`，讓 Preview 不再渲染破損卡片。已補上兩個回歸測試，`pnpm verify` 全數通過。