### PR TITLE
chore(game): trim over-commented recording code [skip review]

### DIFF
--- a/src/components/game/entry/index.tsx
+++ b/src/components/game/entry/index.tsx
@@ -48,10 +48,6 @@ export const EntryContainer = ({
 }) => (
   <div
     className={cn(
-      // Uniform entry box: p-1 + rounded so every entry (committed rows and the
-      // Preview) shares one shape. On the drawer's bg-card the rounding is only
-      // visible once a background is applied -- e.g. the Preview's primary fill
-      // when it becomes the send button.
       "flex w-full flex-none basis-8 flex-row items-center justify-start gap-1 rounded-md p-1",
       className,
     )}
@@ -90,9 +86,7 @@ export const EntryPlayerNumber = ({
   </span>
 );
 
-// Minimum horizontal pointer travel (px) before a drag is recognized as a
-// swipe rather than a tap -- mirrors panel/progress-bar.tsx's capture-on-
-// intent gesture so the two don't diverge on feel.
+// keep in sync with panel/progress-bar.tsx
 const SWIPE_THRESHOLD_PX = 40;
 
 const actionLabel: Record<EntryAction, string> = {
@@ -132,16 +126,6 @@ const EntryRowActions = ({
   </>
 );
 
-/**
- * Interactive row wrapper around <Entry> (D12 group 5): left-swipe reveals
- * the row's action buttons, and tapping the row inline-expands it as an
- * accordion showing the entry's detail + actions, without leaving the list.
- *
- * ponytail: EntryView has no `recordedBy` field yet -- it's populated once
- * the sync-recording change adds authorship. The expanded content shows the
- * entry's existing score/type detail (via <Entry>) plus the composed
- * actions; there's no timestamp field on the model to show either.
- */
 export const EntryRow = ({
   entry,
   players,
@@ -161,9 +145,7 @@ export const EntryRow = ({
   onEdit?: () => void;
   onDelete?: () => void;
   onRollbackToHere?: () => void;
-  // Optional controlled expand/swipe state: when the list owns these (single
-  // open at a time -- tapping another row collapses this one) it passes them
-  // in; standalone usage falls back to local state.
+  // optional controlled state; falls back to local when uncontrolled
   expanded?: boolean;
   onToggleExpand?: () => void;
   swipeRevealed?: boolean;
@@ -192,9 +174,7 @@ export const EntryRow = ({
     if (Math.abs(dx) < SWIPE_THRESHOLD_PX) return;
 
     drag.triggered = true;
-    // Any recognized swipe suppresses the tap the browser synthesizes on
-    // pointerup, so a horizontal drag never also toggles the accordion --
-    // mirrors panel/progress-bar.tsx. Only a left-swipe reveals the actions.
+    // suppress the synthetic tap after a swipe so it doesn't also toggle expand
     suppressClickRef.current = true;
     if (dx < 0) {
       revealSwipe(true);
@@ -213,9 +193,7 @@ export const EntryRow = ({
     toggleExpand();
   };
 
-  // ponytail: delete/rollback are still computed by the last-entry rule, but
-  // hidden until the sync-recording change wires their reducers -- rendering
-  // inert buttons would be misleading.
+  // only edit is wired yet; delete/rollback await sync-recording reducers
   const actions = composeEntryActions(isLatest).filter((a) => a === "edit");
 
   return (

--- a/src/components/game/preview.tsx
+++ b/src/components/game/preview.tsx
@@ -13,16 +13,8 @@ import { cn } from "@/lib/utils";
 import { useEffect, useState } from "react";
 import { RiSendPlaneLine } from "react-icons/ri";
 
-/**
- * Presentational Preview card. The three score-Figures states (idle / undecided
- * / decided) fall out of <Entry>/<Rally> for free from the shape of `entry` --
- * this component only layers the submission feedback on top: a pulse while the
- * draft is incomplete, a ring + send icon once it is complete, and (owned
- * locally, since it is purely a transient UI reaction to a click) a freeze that
- * flashes the background once and demotes the draft to `previousEntry` in
- * place. The container resets this by remounting the card (via `key`) once the
- * real submission advances to the next entry.
- */
+// Draft row: pulses while incomplete, shows a send affordance when complete,
+// and freezes/flashes on submit until the parent remounts it via key.
 export const PreviewCard = ({
   entry,
   previousEntry,
@@ -67,10 +59,6 @@ export const PreviewCard = ({
   const showSendAffordance = Boolean(isEditing && isComplete && !frozen);
 
   return (
-    // A plain row, not a Card: the recording Preview must match the flat
-    // committed entry rows in the drawer (no rounded/ring/shadow frame), so the
-    // peek looks identical whether idle (an EntryRow) or recording. The
-    // completion ring below is the only ring, and only while complete.
     <div
       data-testid="preview-card"
       className={cn("relative grid w-full", className)}
@@ -80,9 +68,6 @@ export const PreviewCard = ({
         onClick={handleClick}
         className={cn(isPulsing && !frozen && "animate-pulse duration-1000")}
       >
-        {/* The fill lives on the Entry box itself (which carries the shared p-1
-            + rounded), so once complete the whole entry reads as a rounded
-            primary send button rather than a framed row. */}
         <Entry
           entry={shownEntry}
           players={players}
@@ -106,12 +91,8 @@ export const PreviewCard = ({
   );
 };
 
-/**
- * Derives the entry-draft state shared by the Preview (this file) and the
- * Summary drawer's in-progress draft row (summary-drawer.tsx) -- the single
- * source of truth for "is input in progress" / "is the draft complete" so the
- * two consumers never diverge on their own copies of these booleans.
- */
+// Single source of truth for the in-progress draft, shared by the Preview and
+// the Summary drawer so they never diverge.
 export const useEntryDraftPreview = (
   gameId: string,
   mode: ReduxGameState["mode"],
@@ -123,8 +104,7 @@ export const useEntryDraftPreview = (
     status: { inProgress, entryIndex },
   } = useAppSelector((state) => state.game[mode]);
 
-  // Guard a transient undefined game (e.g. a rolled-back optimistic mutate) so
-  // the shared Preview hook degrades to "not in progress" instead of crashing.
+  // a rolled-back optimistic mutate can transiently leave game undefined
   if (!game || !inProgress) return { inProgress: false as const };
 
   const { players } = game.teams.home;
@@ -161,13 +141,11 @@ export const useEntryDraftPreview = (
 
   const entry = isEditing || entryIndex === 0 ? draftEntry : previousEntry;
 
-  // No draft and no prior entry (the first entry, before any input): nothing to
-  // preview.
+  // first entry, before any input: nothing to preview
   if (!entry) return { inProgress: false as const };
 
-  // Explicit boolean check so a falsy-but-valid draft value (e.g. num === 0)
-  // never trips the send affordance.
   const { submittable } = getEntryProgress(draft);
+  // === true so a valid num === 0 is not read as incomplete
   const isComplete = submittable === true;
 
   return {
@@ -201,8 +179,7 @@ export const GamePreview = ({
 
   return (
     <PreviewCard
-      // Remounts on the next entry so the local freeze/flash state (owned by
-      // PreviewCard) always starts fresh once the real submission lands.
+      // remount per entry to reset the card's freeze/flash state
       key={entryIndex}
       entry={entry}
       previousEntry={previousEntry}


### PR DESCRIPTION
## What

Trim over-commented recording code — `entry/index.tsx` (26→4 comment lines) and `preview.tsx` (28→8): remove comments that restate the code or narrate design docs; keep only terse non-obvious *why*, and let honest types (optional props) document the contract.

## Why

Follow-up to #350: the merged fix still carried heavy explanatory comments. No logic change — comment/text only. `pnpm verify` green (771 tests).

---

### 摘要（zh-tw）

精簡 game 記錄元件（Entry/Preview）過多的註解，只保留必要的 why，並以誠實型別取代解釋性註解。純註解變更，無邏輯改動。