### PR TITLE
fix(game): integration harness + persist new sets and lineup edits

### DIFF
--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -107,7 +107,7 @@ Defines what belongs in shared setup files versus inline per-test mocks.
 | `jest.setup.frontend.ts`    | Browser APIs (`matchMedia`, `ResizeObserver`, `IntersectionObserver`)                                                                                    | Frontend project (`jest.config.ts` `projects.frontend`)       |
 | `jest.setup.integration.ts` | Starts a real in-memory MongoDB, connects mongoose, clears collections between tests; stubs `@/lib/auth` + `next/headers` so the container is importable | Integration project (`jest.config.ts` `projects.integration`) |
 
-The integration project deliberately does **not** load `jest.setup.backend.ts`: it needs the real Mongoose driver, not the stub. `jest.config.ts` also exposes `globalThis.AsyncLocalStorage` (and forwards it to workers via `jest.preload.integration.cjs`) because Next's server modules — pulled in when real route handlers are imported — capture it at load time.
+The integration project deliberately does **not** load `jest.setup.backend.ts`: it needs the real Mongoose driver, not the stub. `jest.config.ts` also exposes `globalThis.AsyncLocalStorage` (and forwards it to workers via `jest.preload.integration.mjs`) because Next's server modules — pulled in when real route handlers are imported — capture it at load time.
 
 **Rule:** A mock belongs in a setup file when _every_ test in that project needs it to run at all. Browser API stubs and DB connection setup qualify. Business-logic fakes do not.
 

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -10,19 +10,65 @@ See also: [Architecture Overview](./architecture.md) · [Maintenance Policy](./m
 
 Each layer has a designated testing school and defined mock boundaries.
 
-| Layer                                     | School    | What to mock                                             | What stays real                      | Example                           |
-| ----------------------------------------- | --------- | -------------------------------------------------------- | ------------------------------------ | --------------------------------- |
-| Entity (`src/entities/`)                  | Classical | Nothing                                                  | Everything                           | Pure logic, validation            |
-| UseCase (`src/applications/`)             | Classical | Repository & service interfaces                          | Entity logic, use case orchestration | Inject mock repo, verify output   |
-| Infrastructure (`src/infrastructure/`)    | Classical | DB driver (MongoDB/Mongoose via `jest.setup.backend.ts`) | Repository implementation logic      | Global mock already in place      |
-| Controller (`src/interface/controllers/`) | London    | UseCase classes                                          | Controller orchestration             | Stub use case, verify delegation  |
-| Component (`src/components/`)             | Classical | API calls, custom hooks (SWR/Redux)                      | Rendering, user interaction, DOM     | Mock `fetch`/hooks, test behavior |
+| Layer                                     | School    | What to mock                                                     | What stays real                                    | Example                                 |
+| ----------------------------------------- | --------- | ---------------------------------------------------------------- | -------------------------------------------------- | --------------------------------------- |
+| Entity (`src/entities/`)                  | Classical | Nothing                                                          | Everything                                         | Pure logic, validation                  |
+| UseCase (`src/applications/`)             | Classical | Repository & service interfaces                                  | Entity logic, use case orchestration               | Inject mock repo, verify output         |
+| Infrastructure (`src/infrastructure/`)    | Classical | Mongoose/`mongodb` (fully stubbed by `jest.setup.backend.ts`)    | Repository mapping logic                           | No DB; assert on driver call shapes     |
+| Controller (`src/interface/controllers/`) | London    | UseCase classes                                                  | Controller orchestration                           | Stub use case, verify delegation        |
+| Component (`src/components/`)             | Classical | API calls, custom hooks (SWR/Redux)                              | Rendering, user interaction, DOM                   | Mock `fetch`/hooks, test behavior       |
+| Integration (`test/integration/`)         | Classical | Auth services (DI doubles); `next/headers`, `@/lib/auth` imports | Route → controller → use case → repo → **real DB** | Real route handler against memory Mongo |
 
 ### School Emphasis
 
 **Classical (state verification)** — Assert on the _output_ or _resulting state_ after exercising the SUT with real collaborators. Catches integration issues but tests may be slower, and failures may span multiple collaborators, making root causes harder to isolate. This is the default school for all layers except Controller.
 
 **London (behavior verification)** — Assert that the SUT _called the right collaborators with the right arguments_. Provides precise failure messages but couples tests to implementation details. Used only for Controller, where testing through real use cases would duplicate application-layer coverage.
+
+---
+
+## Test Tiers Across the Request Stack
+
+The unit tiers above each isolate a single layer. The **integration tier** wires the whole request stack together against a real database — the seam the mongoose-stubbed backend project cannot reach. Deferred tiers (staging smoke via Bruno, end-to-end via Playwright) are planned but not yet implemented.
+
+```mermaid
+flowchart TB
+    subgraph stack["Request stack"]
+        direction TB
+        P["Presentation<br/>(React components)"]
+        R["API Route<br/>(src/app/api/**/route.ts)"]
+        C["Controller<br/>(src/interface/controllers)"]
+        U["UseCase<br/>(src/applications/usecases)"]
+        Repo["Repository<br/>(src/infrastructure/db)"]
+        DB[("MongoDB")]
+        Auth["Auth services<br/>(authentication / authorization)"]
+        P --> R --> C --> U --> Repo --> DB
+        U -. "resolved via DI" .-> Auth
+    end
+
+    frontend["frontend-unit<br/>Jest + RTL"] -.->|"cuts at"| P
+    backend["backend-unit<br/>Jest, mongoose = jest.fn() stub"] -.->|"cuts at"| U
+    backend -.->|"driver mocked"| Repo
+    integration["integration<br/>real memory Mongo + auth DI doubles"] ==>|"covers full seam"| R
+    integration ==> DB
+    visual["visual<br/>Storybook / Chromatic"] -.->|"pixels of"| P
+    smoke["staging-smoke<br/>Bruno (deferred)"] -.-> R
+    e2e["e2e<br/>Playwright (deferred)"] -.-> P
+```
+
+Per-layer reality under each tier:
+
+| Layer        | frontend-unit | backend-unit         | integration               | visual   |
+| ------------ | ------------- | -------------------- | ------------------------- | -------- |
+| Presentation | **real**      | —                    | —                         | **real** |
+| API Route    | —             | real (driver mocked) | **real**                  | —        |
+| Controller   | —             | real / test-double   | **real**                  | —        |
+| UseCase      | —             | **real**             | **real**                  | —        |
+| Repository   | —             | real (mongoose stub) | **real**                  | —        |
+| Database     | —             | **mocked** (jest.fn) | **real** (memory Mongo)   | —        |
+| Auth         | —             | test-double          | **DI double** (fake user) | —        |
+
+The integration tier is what closes the previously-uncovered **route ↔ usecase ↔ repository ↔ DB** persistence seam: it drives a real `NextRequest` through the exported route handler so route-layer request mapping (`si`/`ei` params, JSON body, forwarded fields) is exercised end to end against a real Mongoose write/read round-trip.
 
 ---
 
@@ -55,10 +101,13 @@ Defines what belongs in shared setup files versus inline per-test mocks.
 
 ### Setup Files
 
-| File                     | What it mocks                                                         | Used by                                                 |
-| ------------------------ | --------------------------------------------------------------------- | ------------------------------------------------------- |
-| `jest.setup.backend.ts`  | MongoDB/Mongoose driver (`mongodb-memory-server`)                     | Backend project (`jest.config.ts` `projects.backend`)   |
-| `jest.setup.frontend.ts` | Browser APIs (`matchMedia`, `ResizeObserver`, `IntersectionObserver`) | Frontend project (`jest.config.ts` `projects.frontend`) |
+| File                        | What it does                                                                                                                                             | Used by                                                       |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| `jest.setup.backend.ts`     | Replaces `mongoose`/`mongodb`/`bson` with `jest.fn()` stubs — no database is contacted                                                                   | Backend project (`jest.config.ts` `projects.backend`)         |
+| `jest.setup.frontend.ts`    | Browser APIs (`matchMedia`, `ResizeObserver`, `IntersectionObserver`)                                                                                    | Frontend project (`jest.config.ts` `projects.frontend`)       |
+| `jest.setup.integration.ts` | Starts a real in-memory MongoDB, connects mongoose, clears collections between tests; stubs `@/lib/auth` + `next/headers` so the container is importable | Integration project (`jest.config.ts` `projects.integration`) |
+
+The integration project deliberately does **not** load `jest.setup.backend.ts`: it needs the real Mongoose driver, not the stub. `jest.config.ts` also exposes `globalThis.AsyncLocalStorage` (and forwards it to workers via `jest.preload.integration.cjs`) because Next's server modules — pulled in when real route handlers are imported — capture it at load time.
 
 **Rule:** A mock belongs in a setup file when _every_ test in that project needs it to run at all. Browser API stubs and DB connection setup qualify. Business-logic fakes do not.
 
@@ -94,6 +143,7 @@ New components in `ui/` and `custom/` must include a Storybook story before the 
 | Repository (infrastructure)      | Jest                                | Classical | DB driver (global setup)        |
 | API controller                   | Jest                                | London    | Use case classes                |
 | React component (behavior)       | Jest + RTL                          | Classical | `fetch`, SWR hooks, Redux store |
+| Full request stack + persistence | Jest (`*.itest.ts`, real memory DB) | Classical | Auth services (DI doubles)      |
 | React component (visual)         | Storybook story                     | —         | —                               |
 | New `ui/` or `custom/` component | Story **required**                  | —         | —                               |
 | New domain component             | Story optional (Jest is sufficient) | —         | —                               |

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,11 +1,26 @@
 /**
- * Jest configuration with two projects for environment isolation:
- * - backend: node environment for entities, applications, infrastructure, interface, API routes
+ * Jest configuration with three projects:
+ * - backend: node environment, mongoose mocked, for entities/applications/infrastructure/interface/API-route unit tests
  * - frontend: jsdom environment for components and lib
+ * - integration: node environment against a real in-memory MongoDB (no mongoose mock)
  */
 
+import { AsyncLocalStorage } from "node:async_hooks";
 import type { Config } from "jest";
 import nextJest from "next/jest.js";
+
+// Next's server modules (pulled in by the integration project's real route
+// imports) capture globalThis.AsyncLocalStorage at import time and otherwise use
+// a stub that throws on use. They load in the real Node context, so expose it on
+// the real global here (covers in-band runs) and forward it into forked Jest
+// workers via NODE_OPTIONS (covers the default parallel runner).
+(globalThis as { AsyncLocalStorage?: unknown }).AsyncLocalStorage ??=
+  AsyncLocalStorage;
+const preload = `${process.cwd()}/jest.preload.integration.mjs`;
+if (!process.env.NODE_OPTIONS?.includes(preload)) {
+  process.env.NODE_OPTIONS =
+    `${process.env.NODE_OPTIONS ?? ""} --import ${preload}`.trim();
+}
 
 const createJestConfig = nextJest({ dir: "./" });
 
@@ -59,10 +74,18 @@ export default async function jestConfig() {
     ],
   };
 
+  const integrationProject: Config = {
+    ...sharedConfig,
+    displayName: "integration",
+    testEnvironment: "node",
+    setupFilesAfterEnv: ["<rootDir>/jest.setup.integration.ts"],
+    testMatch: ["<rootDir>/test/integration/**/*.itest.{js,jsx,ts,tsx}"],
+  };
+
   return {
     collectCoverage: true,
     coverageDirectory: "coverage",
     coverageProvider: "v8",
-    projects: [backendProject, frontendProject],
+    projects: [backendProject, frontendProject, integrationProject],
   } satisfies Config;
 }

--- a/jest.preload.integration.mjs
+++ b/jest.preload.integration.mjs
@@ -1,0 +1,6 @@
+// Preloaded via NODE_OPTIONS=--import before any module in every forked Jest
+// worker. Next captures globalThis.AsyncLocalStorage at import time and falls
+// back to a stub that throws on use when it is absent; expose it up front.
+import { AsyncLocalStorage } from "node:async_hooks";
+
+globalThis.AsyncLocalStorage ??= AsyncLocalStorage;

--- a/jest.setup.integration.ts
+++ b/jest.setup.integration.ts
@@ -1,0 +1,39 @@
+import { MongoMemoryServer } from "mongodb-memory-server";
+import mongoose from "mongoose";
+
+// The DI container eagerly imports the real AuthenticationService, which pulls in
+// Better Auth (ESM, untransformed by Jest) and next/headers. Integration tests
+// swap the auth services via DI (see test/integration/support/auth.ts), so the
+// real implementations only need to be importable, never executed.
+jest.mock("@/lib/auth", () => ({
+  auth: { api: { getSession: jest.fn() } },
+}));
+jest.mock("next/headers", () => ({
+  headers: jest.fn(async () => new Headers()),
+}));
+
+// Real in-memory MongoDB per Jest worker file: each file gets its own server on
+// a random port, so parallel workers never share state. This is the seam the
+// mongoose-mocked `backend` project cannot exercise (route -> usecase -> repo -> DB).
+let mongod: MongoMemoryServer;
+
+// Modules imported by the DI container (Better Auth's Mongo adapter) read
+// MONGODB_URI at import time; give them a placeholder before the real server
+// starts. The placeholder client is lazy and never connects — auth is stubbed.
+process.env.MONGODB_URI ??= "mongodb://127.0.0.1:27017/integration-placeholder";
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  process.env.MONGODB_URI = mongod.getUri();
+  await mongoose.connect(process.env.MONGODB_URI);
+}, 60_000);
+
+afterEach(async () => {
+  const { collections } = mongoose.connection;
+  await Promise.all(Object.values(collections).map((c) => c.deleteMany({})));
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod?.stop();
+});

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "jest-environment-jsdom": "^30.4.1",
     "jest-environment-node": "^30.4.1",
     "knip": "^6.27.0",
+    "mongodb-memory-server": "^11.2.0",
     "next-themes": "^0.4.6",
     "png-to-ico": "^3.0.2",
     "postcss": "^8.5.19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -213,6 +213,9 @@ importers:
       knip:
         specifier: ^6.27.0
         version: 6.27.0
+      mongodb-memory-server:
+        specifier: ^11.2.0
+        version: 11.2.0
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -230,7 +233,7 @@ importers:
         version: 0.8.1(prettier@3.9.5)
       serwist:
         specifier: ^9.5.11
-        version: 9.5.11(browserslist@4.28.2)(typescript@6.0.3)
+        version: 9.5.11(browserslist@4.28.6)(typescript@6.0.3)
       sharp:
         specifier: ^0.35.3
         version: 0.35.3(@types/node@25.9.5)
@@ -4524,6 +4527,9 @@ packages:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
 
+  async-mutex@0.5.0:
+    resolution: {integrity: sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==}
+
   atomically@1.7.0:
     resolution: {integrity: sha512-Xcz9l0z7y9yQ9rdDaxlmaI4uJHf/T8g9hOEzJcsEqX2SjCj4J20uK7+ldkDHMbpJDK76wF7xEIgxc/vSlsfw5w==}
     engines: {node: '>=10.12.0'}
@@ -4547,6 +4553,14 @@ packages:
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
+
+  b4a@1.8.1:
+    resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
+    peerDependencies:
+      react-native-b4a: '*'
+    peerDependenciesMeta:
+      react-native-b4a:
+        optional: true
 
   babel-jest@30.4.1:
     resolution: {integrity: sha512-fATAbM8piYxkiXQp3RBXmZHxZVNJZAVXXfyeyCN2Tida3+qJ8ea9UxhiJ2y4fLO90ZImKt6k9FlcH2+rLkJGhw==}
@@ -4609,6 +4623,43 @@ packages:
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
+
+  bare-events@2.9.1:
+    resolution: {integrity: sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==}
+    peerDependencies:
+      bare-abort-controller: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+
+  bare-fs@4.7.4:
+    resolution: {integrity: sha512-y1kC+ffIx/tPLdTE693uNjHfzTfr+ravR5tvWlMXe25nELbkqV400S71qHDwbkAQ1FVEZobB1NFRzFbCCcyBCQ==}
+    engines: {bare: '>=1.16.0'}
+    peerDependencies:
+      bare-buffer: '*'
+    peerDependenciesMeta:
+      bare-buffer:
+        optional: true
+
+  bare-path@3.1.1:
+    resolution: {integrity: sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==}
+
+  bare-stream@2.13.3:
+    resolution: {integrity: sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==}
+    peerDependencies:
+      bare-abort-controller: '*'
+      bare-buffer: '*'
+      bare-events: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+      bare-buffer:
+        optional: true
+      bare-events:
+        optional: true
+
+  bare-url@2.4.6:
+    resolution: {integrity: sha512-iQxPClE07hETVpbRoX7JXX3v/ZQViCxe/SYCxylRLzdEx1xJAufPptfiOqR8tqiCtmbtMDANKWszzjLu1PMAZQ==}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -5713,6 +5764,9 @@ packages:
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
+  events-universal@1.0.1:
+    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
+
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
@@ -5762,6 +5816,9 @@ packages:
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-fifo@1.3.2:
+    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
   fast-glob@3.3.1:
     resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
@@ -5855,6 +5912,15 @@ packages:
 
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
+
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
 
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
@@ -7386,6 +7452,14 @@ packages:
     resolution: {integrity: sha512-ZoS07RoFqpKYQwAk59qmrx8+jJHNHU30UjlU96QktiGn1ltvDr+vCznLX5DiUBLEpMAHatHNWV1nM/74ul66kA==}
     engines: {node: '>=20.19.0'}
 
+  mongodb-memory-server-core@11.2.0:
+    resolution: {integrity: sha512-vOoDtn0JiLrHvZY81Rp/UtKXXK0rtJHZGZFVnccvJwYitPLNspO0Ty0grqFQOe7iAET8+GI4zAQcphg+R3vxQg==}
+    engines: {node: '>=20.19.0'}
+
+  mongodb-memory-server@11.2.0:
+    resolution: {integrity: sha512-506AD8qvClVx8Raw/WhAUUWBgIXPyi856iC01aa5vAzHmn6WOXC6ulvudkTF7oTMzJxkyA0A84VpD4BpyfqJ9w==}
+    engines: {node: '>=20.19.0'}
+
   mongodb@7.2.0:
     resolution: {integrity: sha512-F/2+BMZtLVhY30ioZp0dAmZ+IRZMBqI+nrv6t5+9/1AIwCa8sMRC3jBf81lpxMhnZgqq8CoUD503Z1oZWq1/sw==}
     engines: {node: '>=20.19.0'}
@@ -7506,6 +7580,10 @@ packages:
 
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
+
+  new-find-package-json@2.0.0:
+    resolution: {integrity: sha512-lDcBsjBSMlj3LXH2v/FW3txlh2pYTjmbOXPYJD93HI5EwuLzI11tdHSIpUMmfq/IOsldj4Ps8M8flhm+pCK4Ew==}
+    engines: {node: '>=12.22.0'}
 
   next-themes@0.4.6:
     resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
@@ -7820,6 +7898,9 @@ packages:
   pbkdf2@3.1.6:
     resolution: {integrity: sha512-BT6eelPB1EyGHo8pC0o9Bl6k6SYVhKO1jEbd3lcTrtr7XHdjP8BW1YpfCV3G9Kwkxgattk+S5q2/RvuttCsS1g==}
     engines: {node: '>= 0.10'}
+
+  pend@1.2.0:
+    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -8665,6 +8746,9 @@ packages:
   stream-http@3.2.0:
     resolution: {integrity: sha512-Oq1bLqisTyK3TSCXpPbT4sdeYNdmyZJv1LxpEm2vu1ZhK89kSE5YXwZc3cWk0MagGaKriBh9mCFbVGtO+vY29A==}
 
+  streamx@2.28.0:
+    resolution: {integrity: sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==}
+
   string-length@4.0.2:
     resolution: {integrity: sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==}
     engines: {node: '>=10'}
@@ -8850,6 +8934,12 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
+  tar-stream@3.2.0:
+    resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
+
+  teex@1.0.1:
+    resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
+
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
@@ -8905,6 +8995,9 @@ packages:
   test-exclude@6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
+
+  text-decoder@1.2.7:
+    resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
 
   timers-browserify@2.0.12:
     resolution: {integrity: sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==}
@@ -9426,6 +9519,10 @@ packages:
 
   yargs@17.7.3:
     resolution: {integrity: sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==}
+    engines: {node: '>=12'}
+
+  yauzl@3.4.0:
+    resolution: {integrity: sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==}
     engines: {node: '>=12'}
 
   yn@3.1.1:
@@ -12541,6 +12638,10 @@ snapshots:
     optionalDependencies:
       browserslist: 4.28.2
 
+  '@serwist/utils@9.5.11(browserslist@4.28.6)':
+    optionalDependencies:
+      browserslist: 4.28.6
+
   '@serwist/window@9.5.11(browserslist@4.28.2)(typescript@6.0.3)':
     dependencies:
       '@types/trusted-types': 2.0.7
@@ -13726,6 +13827,10 @@ snapshots:
 
   async-function@1.0.0: {}
 
+  async-mutex@0.5.0:
+    dependencies:
+      tslib: 2.8.1
+
   atomically@1.7.0: {}
 
   available-typed-arrays@1.0.7:
@@ -13739,6 +13844,8 @@ snapshots:
   axe-core@4.12.1: {}
 
   axobject-query@4.1.0: {}
+
+  b4a@1.8.1: {}
 
   babel-jest@30.4.1(@babel/core@7.29.7):
     dependencies:
@@ -13836,6 +13943,35 @@ snapshots:
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
+
+  bare-events@2.9.1: {}
+
+  bare-fs@4.7.4:
+    dependencies:
+      bare-events: 2.9.1
+      bare-path: 3.1.1
+      bare-stream: 2.13.3(bare-events@2.9.1)
+      bare-url: 2.4.6
+      fast-fifo: 1.3.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  bare-path@3.1.1: {}
+
+  bare-stream@2.13.3(bare-events@2.9.1):
+    dependencies:
+      b4a: 1.8.1
+      streamx: 2.28.0
+      teex: 1.0.1
+    optionalDependencies:
+      bare-events: 2.9.1
+    transitivePeerDependencies:
+      - react-native-b4a
+
+  bare-url@2.4.6:
+    dependencies:
+      bare-path: 3.1.1
 
   base64-js@1.5.1: {}
 
@@ -15057,6 +15193,12 @@ snapshots:
 
   eventemitter3@5.0.4: {}
 
+  events-universal@1.0.1:
+    dependencies:
+      bare-events: 2.9.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+
   events@3.3.0: {}
 
   eventsource-parser@3.1.0: {}
@@ -15151,6 +15293,8 @@ snapshots:
   extendable-error@0.1.7: {}
 
   fast-deep-equal@3.1.3: {}
+
+  fast-fifo@1.3.2: {}
 
   fast-glob@3.3.1:
     dependencies:
@@ -15259,6 +15403,10 @@ snapshots:
       keyv: 4.5.4
 
   flatted@3.4.2: {}
+
+  follow-redirects@1.16.0(debug@4.4.3):
+    optionalDependencies:
+      debug: 4.4.3
 
   for-each@0.3.5:
     dependencies:
@@ -17299,6 +17447,50 @@ snapshots:
       '@types/whatwg-url': 13.0.0
       whatwg-url: 14.2.0
 
+  mongodb-memory-server-core@11.2.0:
+    dependencies:
+      async-mutex: 0.5.0
+      camelcase: 6.3.0
+      debug: 4.4.3
+      find-cache-dir: 3.3.2
+      follow-redirects: 1.16.0(debug@4.4.3)
+      https-proxy-agent: 7.0.6
+      mongodb: 7.5.0
+      new-find-package-json: 2.0.0
+      semver: 7.8.5
+      tar-stream: 3.2.0
+      tslib: 2.8.1
+      yauzl: 3.4.0
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-providers'
+      - '@mongodb-js/zstd'
+      - bare-abort-controller
+      - bare-buffer
+      - gcp-metadata
+      - kerberos
+      - mongodb-client-encryption
+      - react-native-b4a
+      - snappy
+      - socks
+      - supports-color
+
+  mongodb-memory-server@11.2.0:
+    dependencies:
+      mongodb-memory-server-core: 11.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-providers'
+      - '@mongodb-js/zstd'
+      - bare-abort-controller
+      - bare-buffer
+      - gcp-metadata
+      - kerberos
+      - mongodb-client-encryption
+      - react-native-b4a
+      - snappy
+      - socks
+      - supports-color
+
   mongodb@7.2.0:
     dependencies:
       '@mongodb-js/saslprep': 1.4.12
@@ -17364,6 +17556,12 @@ snapshots:
   negotiator@1.0.0: {}
 
   neo-async@2.6.2: {}
+
+  new-find-package-json@2.0.0:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   next-themes@0.4.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
@@ -17813,6 +18011,8 @@ snapshots:
       safe-buffer: 5.2.1
       sha.js: 2.4.12
       to-buffer: 1.2.2
+
+  pend@1.2.0: {}
 
   picocolors@1.1.1: {}
 
@@ -18562,6 +18762,15 @@ snapshots:
     transitivePeerDependencies:
       - browserslist
 
+  serwist@9.5.11(browserslist@4.28.6)(typescript@6.0.3):
+    dependencies:
+      '@serwist/utils': 9.5.11(browserslist@4.28.6)
+      idb: 8.0.3
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - browserslist
+
   set-cookie-parser@3.1.2: {}
 
   set-function-length@1.2.2:
@@ -18853,6 +19062,15 @@ snapshots:
       readable-stream: 3.6.2
       xtend: 4.0.2
 
+  streamx@2.28.0:
+    dependencies:
+      events-universal: 1.0.1
+      fast-fifo: 1.3.2
+      text-decoder: 1.2.7
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
   string-length@4.0.2:
     dependencies:
       char-regex: 1.0.2
@@ -19038,6 +19256,24 @@ snapshots:
 
   tapable@2.3.3: {}
 
+  tar-stream@3.2.0:
+    dependencies:
+      b4a: 1.8.1
+      bare-fs: 4.7.4
+      fast-fifo: 1.3.2
+      streamx: 2.28.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
+  teex@1.0.1:
+    dependencies:
+      streamx: 2.28.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
   term-size@2.2.1: {}
 
   terser-webpack-plugin@5.6.1(@swc/core@1.15.32)(esbuild@0.28.1)(postcss@8.5.19)(webpack@5.108.4(@swc/core@1.15.32)(esbuild@0.28.1)(postcss@8.5.19)):
@@ -19064,6 +19300,12 @@ snapshots:
       '@istanbuljs/schema': 0.1.6
       glob: 7.2.3
       minimatch: 3.1.5
+
+  text-decoder@1.2.7:
+    dependencies:
+      b4a: 1.8.1
+    transitivePeerDependencies:
+      - react-native-b4a
 
   timers-browserify@2.0.12:
     dependencies:
@@ -19705,6 +19947,10 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yauzl@3.4.0:
+    dependencies:
+      pend: 1.2.0
 
   yn@3.1.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,7 @@ allowBuilds:
   "@swc/core": false
   core-js-pure: true
   esbuild: true
+  mongodb-memory-server: false
   sharp: true
   unrs-resolver: true
 

--- a/src/app/api/games/[gameId]/sets/route.ts
+++ b/src/app/api/games/[gameId]/sets/route.ts
@@ -46,7 +46,10 @@ export const PUT = (
 
     const input = {
       params: { gameId, setIndex },
-      data: { options: request.options },
+      data: {
+        lineup: request.lineup,
+        options: request.options,
+      },
     };
 
     const game = await updateSetController(input);

--- a/src/applications/usecases/game/create-set.usecase.ts
+++ b/src/applications/usecases/game/create-set.usecase.ts
@@ -56,7 +56,8 @@ export class CreateSetUseCase implements ICreateSetUseCase {
     const activePlayerIds = new Set([...startingPlayers, ...liberoPlayers]);
 
     game.teams.home.players.forEach((player) => {
-      if (activePlayerIds.has(player.id.toString())) {
+      // Guest players have a null id and never appear in a lineup's active set.
+      if (player.id && activePlayerIds.has(player.id.toString())) {
         player.stats[params.setIndex] = new PlayerStatsClass();
       }
     });

--- a/src/applications/usecases/game/update-set.usecase.ts
+++ b/src/applications/usecases/game/update-set.usecase.ts
@@ -4,12 +4,14 @@ import type { IAuthorizationService } from "@/applications/services/auth/authori
 import { NotFoundError, GameReason } from "@/entities/errors";
 import { type Game, type Set } from "@/entities/game";
 import { PlayerRole } from "@/entities/player";
+import { type Lineup } from "@/entities/team";
 import { TYPES } from "@/infrastructure/di/types";
 import { inject, injectable } from "inversify";
 
 export interface IUpdateSetInput {
   params: { gameId: string; setIndex: number };
   data: {
+    lineup?: Lineup;
     options: Set["options"];
   };
 }
@@ -48,6 +50,7 @@ export class UpdateSetUseCase implements IUpdateSetUseCase {
       throw new NotFoundError(GameReason.SET_NOT_FOUND, "Set not found");
 
     game.sets[params.setIndex].options = data.options;
+    if (data.lineup) game.sets[params.setIndex].lineups.home = data.lineup;
 
     const updatedGame = await this.gameRepository.update(params.gameId, game);
 

--- a/src/components/game/__tests__/set-options-panel.test.tsx
+++ b/src/components/game/__tests__/set-options-panel.test.tsx
@@ -5,6 +5,7 @@ import userEvent from "@testing-library/user-event";
 
 const mockMutate = jest.fn();
 const mockRouterPush = jest.fn();
+const mockToast = jest.fn();
 
 jest.mock("next/navigation", () => ({
   useRouter: () => ({ push: mockRouterPush }),
@@ -31,7 +32,7 @@ jest.mock("@/lib/api/error-toast", () => ({
 }));
 
 jest.mock("@/components/ui/use-toast", () => ({
-  useToast: () => ({ toast: jest.fn() }),
+  useToast: () => ({ toast: mockToast }),
 }));
 
 jest.mock("@/lib/redux/hooks", () => ({
@@ -100,5 +101,25 @@ describe("Options (set-options panel) submitting state", () => {
     await user.click(btn);
 
     await waitFor(() => expect(btn).toBeEnabled());
+  });
+
+  it("fires a success toast after a successful save", async () => {
+    mockApiClient.mockResolvedValue({
+      sets: [],
+      teams: { home: { players: [] } },
+    });
+
+    const user = userEvent.setup();
+    render(<Options gameId="rec-1" />);
+
+    await user.click(
+      screen.getByRole("button", { name: /開始新一局|儲存設定/ }),
+    );
+
+    await waitFor(() =>
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "成功" }),
+      ),
+    );
   });
 });

--- a/src/components/game/set-options/panel/options.tsx
+++ b/src/components/game/set-options/panel/options.tsx
@@ -85,6 +85,10 @@ export const Options = ({ gameId }: { gameId: string }) => {
       );
       mutate(result, false);
       setLiberoDialogOpen(false);
+      toast({
+        title: "成功",
+        description: isNewSet ? "新一局已開始" : "本局設定已儲存",
+      });
       if (isNewSet) router.push(`/game/${gameId}/sets/${setIndex}/entry`);
     } catch (error) {
       showErrorToast(error, toast);

--- a/src/infrastructure/db/repositories/game.repository.mongo.ts
+++ b/src/infrastructure/db/repositories/game.repository.mongo.ts
@@ -326,7 +326,11 @@ export class GameRepositoryImpl implements IGameRepository {
   async update(id: string, data: Partial<Game>): Promise<Game> {
     try {
       const doc = await this.model
-        .findByIdAndUpdate(id, { $set: this.toGameDoc(data) }, { new: true })
+        .findByIdAndUpdate(
+          id,
+          { $set: this.toGameDoc(data) },
+          { returnDocument: "after" },
+        )
         .exec();
       if (!doc)
         throw new NotFoundError(

--- a/test/integration/game-rally.itest.ts
+++ b/test/integration/game-rally.itest.ts
@@ -1,0 +1,69 @@
+import { MoveType } from "@/entities/game";
+import { GameReason } from "@/entities/errors";
+import type { GameRepositoryImpl } from "@/infrastructure/db/repositories/game.repository.mongo";
+import { container } from "@/infrastructure/di/inversify.config";
+import { TYPES } from "@/infrastructure/di/types";
+import { POST as createRally } from "@/app/api/games/[gameId]/sets/rallies/route";
+import { POST as createSet } from "@/app/api/games/[gameId]/sets/route";
+import { useFakeAuth } from "./support/auth";
+import { callRoute } from "./support/request";
+import { seedGame, type SeededGame } from "./support/seed";
+
+const rally = {
+  win: true,
+  home: { score: 1, type: MoveType.ATTACK, num: 0 },
+  away: { score: 0, type: MoveType.ATTACK, num: 0 },
+};
+
+const options = { serve: "home", time: { start: "10:00", end: "" } };
+
+describe("POST /api/games/:id/sets/rallies", () => {
+  let seeded: SeededGame;
+
+  beforeEach(async () => {
+    useFakeAuth();
+    // A guest player on the roster is the real-world trigger for the 404:
+    // create-set used to crash on its null id, so the set never persisted.
+    seeded = await seedGame({ includeGuest: true });
+  });
+
+  const repo = () => container.get<GameRepositoryImpl>(TYPES.GameRepository);
+
+  it("creates the first set, persists it, then records a rally", async () => {
+    const created = await callRoute(createSet, {
+      gameId: seeded.gameId,
+      method: "POST",
+      query: { si: 0 },
+      body: { lineup: seeded.lineup, options },
+    });
+    expect(created.status).toBe(201);
+
+    // The set must actually be in the database, not just in the response.
+    const afterSet = await repo().findById(seeded.gameId);
+    expect(afterSet!.sets).toHaveLength(1);
+
+    const res = await callRoute(createRally, {
+      gameId: seeded.gameId,
+      method: "POST",
+      query: { si: 0, ei: 0 },
+      body: rally,
+    });
+
+    expect(res.status).toBe(200);
+    const afterRally = await repo().findById(seeded.gameId);
+    expect(afterRally!.sets[0].entries).toHaveLength(1);
+  });
+
+  it("returns 404 SET_NOT_FOUND for a set index that does not exist", async () => {
+    const res = await callRoute(createRally, {
+      gameId: seeded.gameId,
+      method: "POST",
+      query: { si: 0, ei: 0 },
+      body: rally,
+    });
+    expect(res.status).toBe(404);
+    expect((res.json as { reason?: string }).reason).toBe(
+      GameReason.SET_NOT_FOUND,
+    );
+  });
+});

--- a/test/integration/smoke.itest.ts
+++ b/test/integration/smoke.itest.ts
@@ -1,0 +1,36 @@
+import { GameRepositoryImpl } from "@/infrastructure/db/repositories/game.repository.mongo";
+import { container } from "@/infrastructure/di/inversify.config";
+import { TYPES } from "@/infrastructure/di/types";
+import mongoose from "mongoose";
+import { useFakeAuth } from "./support/auth";
+import { seedGame } from "./support/seed";
+
+describe("integration harness smoke", () => {
+  beforeEach(() => useFakeAuth());
+
+  it("connects to a real in-memory mongo", () => {
+    expect(mongoose.connection.readyState).toBe(1);
+  });
+
+  it("resolves the real (unmocked) game repository from the container", () => {
+    const repo = container.get(TYPES.GameRepository);
+    expect(repo).toBeInstanceOf(GameRepositoryImpl);
+  });
+
+  it("persists and reads back a seeded game", async () => {
+    const { gameId, playerIds } = await seedGame();
+    const repo = container.get<GameRepositoryImpl>(TYPES.GameRepository);
+    const game = await repo.findById(gameId);
+
+    expect(game).not.toBeNull();
+    expect(game!.teams.home.players.map((p) => p.id)).toEqual(playerIds);
+    expect(game!.sets).toEqual([]);
+  });
+
+  it("clears collections between tests", async () => {
+    const count = await mongoose.connection
+      .collection("games")
+      .countDocuments();
+    expect(count).toBe(0);
+  });
+});

--- a/test/integration/support/auth.ts
+++ b/test/integration/support/auth.ts
@@ -1,0 +1,37 @@
+import type { IAuthenticationService } from "@/applications/services/auth/authentication.service.interface";
+import type { IAuthorizationService } from "@/applications/services/auth/authorization.service.interface";
+import type { User } from "@/entities/user";
+import { PlayerRole } from "@/entities/player";
+import { container } from "@/infrastructure/di/inversify.config";
+import { TYPES } from "@/infrastructure/di/types";
+
+export const FAKE_USER: User = {
+  id: "0".repeat(24),
+  name: "Test User",
+  email: "test@example.com",
+  emailVerified: true,
+};
+
+/**
+ * Replace the real auth services with doubles so integration tests exercise the
+ * route -> usecase -> repository -> DB seam without a Better Auth session.
+ * Returns a restore fn; the authenticated userId and granted role are overridable.
+ */
+export const useFakeAuth = ({
+  userId = FAKE_USER.id,
+  role = PlayerRole.OWNER,
+}: { userId?: string; role?: PlayerRole } = {}) => {
+  const authentication: IAuthenticationService = {
+    verifySession: async () => ({ ...FAKE_USER, id: userId }),
+  };
+  const authorization: IAuthorizationService = {
+    verifyTeamRole: async () => {},
+    verifyIsTeamAdmin: async () => {},
+    verifyIsTeamOwner: async () => {},
+    verifyPlayerRole: async () => {},
+    getPlayerRole: async () => role,
+  };
+
+  container.rebind(TYPES.AuthenticationService).toConstantValue(authentication);
+  container.rebind(TYPES.AuthorizationService).toConstantValue(authorization);
+};

--- a/test/integration/support/request.ts
+++ b/test/integration/support/request.ts
@@ -1,0 +1,39 @@
+import { NextRequest } from "next/server";
+
+type RouteHandler = (
+  req: NextRequest,
+  props: { params: Promise<{ gameId: string }> },
+) => Promise<Response>;
+
+interface CallOptions {
+  gameId: string;
+  method: "POST" | "PUT";
+  body?: unknown;
+  /** search params, e.g. { si: 0, ei: 0 } */
+  query?: Record<string, string | number>;
+}
+
+/**
+ * Invoke a real route handler with a real NextRequest, mirroring how Next.js
+ * calls it: JSON body, `?si=&ei=` search params, and awaited `params`.
+ */
+export const callRoute = async (
+  handler: RouteHandler,
+  { gameId, method, body, query = {} }: CallOptions,
+): Promise<{ status: number; json: unknown }> => {
+  const search = new URLSearchParams(
+    Object.fromEntries(Object.entries(query).map(([k, v]) => [k, String(v)])),
+  ).toString();
+  const url = `http://localhost/api/games/${gameId}/sets${search ? `?${search}` : ""}`;
+
+  const req = new NextRequest(url, {
+    method,
+    headers: { "Content-Type": "application/json" },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+
+  const res = await handler(req, {
+    params: Promise.resolve({ gameId }),
+  });
+  return { status: res.status, json: await res.json() };
+};

--- a/test/integration/support/seed.ts
+++ b/test/integration/support/seed.ts
@@ -1,0 +1,83 @@
+import type { IGameRepository } from "@/applications/repositories/game.repository.interface";
+import type { Game } from "@/entities/game";
+import { Position } from "@/entities/team";
+import type { Lineup } from "@/entities/team";
+import { container } from "@/infrastructure/di/inversify.config";
+import { TYPES } from "@/infrastructure/di/types";
+import { Types } from "mongoose";
+
+const oid = () => new Types.ObjectId().toString();
+
+const emptyTeam = (
+  name: string,
+  players: Game["teams"]["home"]["players"],
+) => ({
+  id: oid(),
+  name,
+  players,
+  staffs: [],
+  stats: [],
+});
+
+/** A lineup referencing the given player ids for the starting six. */
+export const lineupFor = (playerIds: string[]): Lineup => ({
+  options: { liberoReplaceMode: 0, liberoReplacePosition: Position.NONE },
+  starting: playerIds.slice(0, 6).map((id, i) => ({
+    id,
+    position: [
+      Position.OH,
+      Position.MB,
+      Position.OP,
+      Position.OH,
+      Position.MB,
+      Position.S,
+    ][i],
+  })),
+  liberos: [],
+  substitutes: [],
+});
+
+export interface SeededGame {
+  gameId: string;
+  teamId: string;
+  playerIds: string[];
+  lineup: Lineup;
+}
+
+/** Persist a minimal game (home team with 6 players, no sets) for reuse. */
+export const seedGame = async ({
+  includeGuest = false,
+}: { includeGuest?: boolean } = {}): Promise<SeededGame> => {
+  const repo = container.get<IGameRepository>(TYPES.GameRepository);
+  const teamId = oid();
+  const playerIds = Array.from({ length: 6 }, oid);
+  const players = playerIds.map((id, i) => ({
+    id,
+    name: `Player ${i + 1}`,
+    number: i + 1,
+    stats: [],
+  }));
+  // Guest players carry no linked account: their persisted playerId is null,
+  // which round-trips to a null domain id.
+  if (includeGuest) {
+    players.push({
+      id: null as unknown as string,
+      name: "Guest",
+      number: 99,
+      stats: [],
+    });
+  }
+
+  const game = await repo.create({
+    win: false,
+    teamId,
+    info: { scoring: { setCount: 3, decidingSetPoints: 15 } },
+    teams: {
+      home: emptyTeam("Home", players),
+      away: emptyTeam("Away", []),
+    },
+    sets: [],
+  } as Omit<Game, "id">);
+
+  return { gameId: game.id, teamId, playerIds, lineup: lineupFor(playerIds) };
+};

--- a/test/integration/update-set.itest.ts
+++ b/test/integration/update-set.itest.ts
@@ -1,0 +1,48 @@
+import { Position } from "@/entities/team";
+import type { GameRepositoryImpl } from "@/infrastructure/db/repositories/game.repository.mongo";
+import { container } from "@/infrastructure/di/inversify.config";
+import { TYPES } from "@/infrastructure/di/types";
+import {
+  POST as createSet,
+  PUT as updateSet,
+} from "@/app/api/games/[gameId]/sets/route";
+import { useFakeAuth } from "./support/auth";
+import { callRoute } from "./support/request";
+import { seedGame, type SeededGame } from "./support/seed";
+
+const options = { serve: "home", time: { start: "10:00", end: "" } };
+
+describe("PUT /api/games/:id/sets", () => {
+  let seeded: SeededGame;
+
+  beforeEach(async () => {
+    useFakeAuth();
+    seeded = await seedGame();
+  });
+
+  const repo = () => container.get<GameRepositoryImpl>(TYPES.GameRepository);
+
+  it("persists an edited lineup, not just the options", async () => {
+    await callRoute(createSet, {
+      gameId: seeded.gameId,
+      method: "POST",
+      query: { si: 0 },
+      body: { lineup: seeded.lineup, options },
+    });
+
+    // Move the setter (index 5) into the outside-hitter position.
+    const editedLineup = structuredClone(seeded.lineup);
+    editedLineup.starting[5].position = Position.OH;
+
+    const res = await callRoute(updateSet, {
+      gameId: seeded.gameId,
+      method: "PUT",
+      query: { si: 0 },
+      body: { lineup: editedLineup, options },
+    });
+    expect(res.status).toBe(200);
+
+    const after = await repo().findById(seeded.gameId);
+    expect(after!.sets[0].lineups.home.starting[5].position).toBe(Position.OH);
+  });
+});


### PR DESCRIPTION
## What

Adds a real-DB integration test layer and fixes two game-recording persistence bugs it uncovered.

### Integration harness (ATE-90)
- New `integration` Jest project (node env, own `testMatch`) that runs against an ephemeral `mongodb-memory-server` — no mongoose mocking — invoking **real route handlers** with auth rebound to a DI test-double (bypasses Google OAuth). Support helpers: `auth`, `request`, `seed`.
- Corrects `docs/testing-strategy.md` (it claimed a real-DB setup that did not exist) and adds a layered flow diagram of what each test tier covers.

### Fix: rally submission 404'd — new set never persisted (ATE-92)
Root cause: `create-set` called `player.id.toString()` on every roster player, but **guest players carry a null id**, so it threw before the set was saved. The set never persisted, and later rally submission returned 404 `SET_NOT_FOUND`. Guarded on `player.id`; covered by a red-first integration test seeding a roster with a guest.

### Fix: set update dropped lineup edits + no feedback (ATE-93)
`PUT /sets` forwarded only `options`, silently discarding the submitted lineup. Thread `lineup` through the route and use case, add a success toast, and replace the deprecated `findByIdAndUpdate` `new` option with `returnDocument`.

`pnpm verify` green — 779 tests across 3 projects (backend, frontend, integration).

---

### 摘要（zh-tw）

新增真實 DB 的 integration 測試層（Jest + mongodb-memory-server + DI 假 auth，繞過 OAuth，打真實 route handler），並修好它揪出的兩個持久化 bug：(1) rally 送出 404 — 名單含 guest player（null id）使 create-set 拋錯、set 從未存檔；(2) 單局設定 PUT 丟棄 lineup、且無成功提示。並更正 testing-strategy.md（原宣稱的 real-DB 設定實際不存在）加上分層流程圖。