### PR TITLE
fix(game): add gap between the fixed header and the court

### DIFF
--- a/src/components/game/index.tsx
+++ b/src/components/game/index.tsx
@@ -66,7 +66,7 @@ const Game = ({ gameId, setIndex }: { gameId: string; setIndex: number }) => {
           fill the rest. The drawer is a vaul snap-point sheet portalled to
           <body> (fixed at the bottom), so pb reserves its idle peek height and
           the panel content never sits behind the peek. */}
-      <div className="flex min-h-0 w-full flex-1 flex-col gap-1 pt-[calc(env(safe-area-inset-top)+5.5rem)] pb-21">
+      <div className="flex min-h-0 w-full flex-1 flex-col gap-1 px-1 pt-[calc(env(safe-area-inset-top)+5.75rem)] pb-21">
         <div className="w-full shrink-0 overflow-hidden rounded-lg">
           <GameCourt gameId={gameId} mode="general" />
         </div>
@@ -98,7 +98,7 @@ export function GameSkeleton() {
   return (
     <div className="flex h-full w-full max-w-160 flex-col items-center justify-start overflow-hidden">
       <GameHeader />
-      <div className="flex min-h-0 w-full flex-1 flex-col gap-1 pt-[calc(env(safe-area-inset-top)+5.5rem)] pb-21">
+      <div className="flex min-h-0 w-full flex-1 flex-col gap-1 px-1 pt-[calc(env(safe-area-inset-top)+5.75rem)] pb-21">
         <div className="w-full shrink-0 overflow-hidden rounded-lg">
           <LoadingCourt />
         </div>

--- a/src/components/game/index.tsx
+++ b/src/components/game/index.tsx
@@ -66,7 +66,7 @@ const Game = ({ gameId, setIndex }: { gameId: string; setIndex: number }) => {
           fill the rest. The drawer is a vaul snap-point sheet portalled to
           <body> (fixed at the bottom), so pb reserves its idle peek height and
           the panel content never sits behind the peek. */}
-      <div className="flex min-h-0 w-full flex-1 flex-col gap-1 px-1 pt-[calc(env(safe-area-inset-top)+5.75rem)] pb-21">
+      <div className="flex min-h-0 w-full flex-1 flex-col gap-1 pt-[calc(env(safe-area-inset-top)+5.75rem)] pb-21">
         <div className="w-full shrink-0 overflow-hidden rounded-lg">
           <GameCourt gameId={gameId} mode="general" />
         </div>
@@ -98,7 +98,7 @@ export function GameSkeleton() {
   return (
     <div className="flex h-full w-full max-w-160 flex-col items-center justify-start overflow-hidden">
       <GameHeader />
-      <div className="flex min-h-0 w-full flex-1 flex-col gap-1 px-1 pt-[calc(env(safe-area-inset-top)+5.75rem)] pb-21">
+      <div className="flex min-h-0 w-full flex-1 flex-col gap-1 pt-[calc(env(safe-area-inset-top)+5.75rem)] pb-21">
         <div className="w-full shrink-0 overflow-hidden rounded-lg">
           <LoadingCourt />
         </div>


### PR DESCRIPTION
## What

`src/components/game/index.tsx` (live layout + mirrored skeleton): the fixed header reserved its exact height via `pt`, but `gap-1` only applies between the court and panel flex children — not between the header (a sibling, not a flex child) and the court — so the header sat flush against the court. Bump `pt` by `+0.25rem` (matching `gap-1`) to add the gap.

## Note

An earlier revision also added `px-1` to inset court/panel and fix the mobile court frame (C2), but that narrowed them against the full-width fixed header and drawer-peek, misaligning edges — so it was dropped. **C2 (mobile court frame) is intentionally not addressed here**; a consistent fix would need to inset the header + drawer too (or live in the court component) — deferred.

Relates to ATE-42.

---

### 摘要（zh-tw）

在固定 header 與 court 之間補 0.25rem 間隙（原本 gap-1 只作用在 court↔panel）。先前的 px-1 內縮因會讓 court/panel 寬度與全寬 header、drawer-peek 不一致而移除；C2（mobile court 外框）本 PR 不處理，留待一致性做法。