### PR TITLE
fix(game): validate lineup player ids against team roster

### DIFF
--- a/src/applications/usecases/game/create-set.usecase.ts
+++ b/src/applications/usecases/game/create-set.usecase.ts
@@ -7,6 +7,7 @@ import {
   type Set,
   PlayerStatsClass,
   TeamStatsClass,
+  validateLineupPlayers,
 } from "@/entities/game";
 import { PlayerRole } from "@/entities/player";
 import { type Lineup } from "@/entities/team";
@@ -50,6 +51,8 @@ export class CreateSetUseCase implements ICreateSetUseCase {
       user.id.toString(),
       PlayerRole.MEMBER,
     );
+
+    validateLineupPlayers(data.lineup, game.teams.home.players);
 
     const startingPlayers = data.lineup.starting.map((player) => player.id);
     const liberoPlayers = data.lineup.liberos.map((player) => player.id);

--- a/src/applications/usecases/game/update-set.usecase.ts
+++ b/src/applications/usecases/game/update-set.usecase.ts
@@ -2,7 +2,7 @@ import type { IGameRepository } from "@/applications/repositories/game.repositor
 import type { IAuthenticationService } from "@/applications/services/auth/authentication.service.interface";
 import type { IAuthorizationService } from "@/applications/services/auth/authorization.service.interface";
 import { NotFoundError, GameReason } from "@/entities/errors";
-import { type Game, type Set } from "@/entities/game";
+import { type Game, type Set, validateLineupPlayers } from "@/entities/game";
 import { PlayerRole } from "@/entities/player";
 import { type Lineup } from "@/entities/team";
 import { TYPES } from "@/infrastructure/di/types";
@@ -51,7 +51,10 @@ export class UpdateSetUseCase implements IUpdateSetUseCase {
       throw new NotFoundError(GameReason.SET_NOT_FOUND, "Set not found");
 
     set.options = data.options;
-    if (data.lineup) set.lineups.home = data.lineup;
+    if (data.lineup) {
+      validateLineupPlayers(data.lineup, game.teams.home.players);
+      set.lineups.home = data.lineup;
+    }
 
     const updatedGame = await this.gameRepository.update(params.gameId, game);
 

--- a/src/applications/usecases/game/update-set.usecase.ts
+++ b/src/applications/usecases/game/update-set.usecase.ts
@@ -50,9 +50,11 @@ export class UpdateSetUseCase implements IUpdateSetUseCase {
     if (!set)
       throw new NotFoundError(GameReason.SET_NOT_FOUND, "Set not found");
 
-    set.options = data.options;
     if (data.lineup) {
       validateLineupPlayers(data.lineup, game.teams.home.players);
+    }
+    set.options = data.options;
+    if (data.lineup) {
       set.lineups.home = data.lineup;
     }
 

--- a/src/entities/__tests__/game.test.ts
+++ b/src/entities/__tests__/game.test.ts
@@ -1,6 +1,29 @@
-import { MoveType, PlayerStatsClass, TeamStatsClass } from "@/entities/game";
+import { ValidationError } from "@/entities/errors";
+import {
+  MoveType,
+  type Player,
+  PlayerStatsClass,
+  TeamStatsClass,
+  validateLineupPlayers,
+} from "@/entities/game";
+import { Position, type Lineup } from "@/entities/team";
 
 type PlayerStatsMoveType = Exclude<MoveType, MoveType.UNFORCED>;
+
+const player = (id: string | null): Player => ({
+  id: id as string,
+  name: "P",
+  number: 1,
+  stats: [],
+});
+
+const lineup = (overrides: Partial<Lineup> = {}): Lineup => ({
+  options: { liberoReplaceMode: 0, liberoReplacePosition: Position.NONE },
+  starting: [],
+  liberos: [],
+  substitutes: [],
+  ...overrides,
+});
 
 describe("PlayerStatsClass", () => {
   let stats: PlayerStatsClass;
@@ -59,5 +82,63 @@ describe("TeamStatsClass", () => {
     expect(stats.timeout).toBe(2);
     expect(stats.substitution).toBe(6);
     expect(stats.challenge).toBe(2);
+  });
+});
+
+describe("validateLineupPlayers", () => {
+  const roster = [player("a"), player("b"), player("c")];
+
+  it("passes when every referenced id is on the roster", () => {
+    expect(() =>
+      validateLineupPlayers(
+        lineup({
+          starting: [{ id: "a" }, { id: "b" }],
+          liberos: [{ id: "c" }],
+        }),
+        roster,
+      ),
+    ).not.toThrow();
+  });
+
+  it("throws ValidationError when a referenced id is not on the roster", () => {
+    expect(() =>
+      validateLineupPlayers(
+        lineup({ starting: [{ id: "a" }, { id: "ghost" }] }),
+        roster,
+      ),
+    ).toThrow(ValidationError);
+  });
+
+  it("validates nested sub ids", () => {
+    expect(() =>
+      validateLineupPlayers(
+        lineup({
+          starting: [{ id: "a", sub: { id: "ghost", entryIndex: {} } }],
+        }),
+        roster,
+      ),
+    ).toThrow(ValidationError);
+  });
+
+  it("skips null references (empty slots / unassigned subs)", () => {
+    expect(() =>
+      validateLineupPlayers(
+        lineup({
+          starting: [{ id: "a", sub: { id: null, entryIndex: {} } }],
+          substitutes: [{ id: null }],
+        }),
+        roster,
+      ),
+    ).not.toThrow();
+  });
+
+  it("never treats a null-id guest on the roster as a valid target", () => {
+    const rosterWithGuest = [player("a"), player(null)];
+    expect(() =>
+      validateLineupPlayers(
+        lineup({ starting: [{ id: "a" }, { id: "null" }] }),
+        rosterWithGuest,
+      ),
+    ).toThrow(ValidationError);
   });
 });

--- a/src/entities/__tests__/game.test.ts
+++ b/src/entities/__tests__/game.test.ts
@@ -132,6 +132,19 @@ describe("validateLineupPlayers", () => {
     ).not.toThrow();
   });
 
+  it.each([
+    ["null", null],
+    ["undefined", undefined],
+    ["empty object", {}],
+    ["non-array starting", { ...lineup(), starting: "nope" }],
+    ["non-array liberos", { ...lineup(), liberos: 42 }],
+    ["non-array substitutes", { ...lineup(), substitutes: null }],
+  ])("throws ValidationError for a malformed lineup (%s)", (_label, bad) => {
+    expect(() =>
+      validateLineupPlayers(bad as unknown as Lineup, roster),
+    ).toThrow(ValidationError);
+  });
+
   it("never treats a null-id guest on the roster as a valid target", () => {
     const rosterWithGuest = [player("a"), player(null)];
     expect(() =>

--- a/src/entities/game.ts
+++ b/src/entities/game.ts
@@ -1,3 +1,4 @@
+import { ValidationError, CommonReason } from "@/entities/errors";
 import { Lineup } from "@/entities/team";
 
 export enum MatchPhase {
@@ -88,6 +89,35 @@ export type Player = {
   number: number;
   stats: PlayerStats[];
 };
+
+/**
+ * Validate that every player id referenced by a lineup exists on the roster.
+ * Guest players carry a null id, so only non-null roster ids are allowed
+ * targets; null references in the lineup are empty slots and are skipped.
+ * Throws ValidationError if a referenced id is not on the roster.
+ */
+export function validateLineupPlayers(lineup: Lineup, roster: Player[]): void {
+  const rosterIds = new Set(
+    roster
+      .filter((player) => player.id != null)
+      .map((player) => String(player.id)),
+  );
+
+  const referencedIds = [
+    ...lineup.starting,
+    ...lineup.liberos,
+    ...lineup.substitutes,
+  ].flatMap((entry) => [entry.id, entry.sub?.id ?? null]);
+
+  for (const id of referencedIds) {
+    if (id != null && !rosterIds.has(String(id))) {
+      throw new ValidationError(
+        CommonReason.INVALID_INPUT,
+        "Lineup references a player not on the team roster",
+      );
+    }
+  }
+}
 
 export type TeamStats = PlayerStats & {
   [MoveType.UNFORCED]: { success: number; error: number };

--- a/src/entities/game.ts
+++ b/src/entities/game.ts
@@ -94,9 +94,25 @@ export type Player = {
  * Validate that every player id referenced by a lineup exists on the roster.
  * Guest players carry a null id, so only non-null roster ids are allowed
  * targets; null references in the lineup are empty slots and are skipped.
- * Throws ValidationError if a referenced id is not on the roster.
+ * Throws ValidationError if the lineup shape is malformed or a referenced id
+ * is not on the roster.
  */
 export function validateLineupPlayers(lineup: Lineup, roster: Player[]): void {
+  // The lineup arrives unvalidated from the request body, so reject a
+  // malformed shape here instead of letting a spread throw a raw TypeError.
+  if (
+    lineup == null ||
+    typeof lineup !== "object" ||
+    !Array.isArray(lineup.starting) ||
+    !Array.isArray(lineup.liberos) ||
+    !Array.isArray(lineup.substitutes)
+  ) {
+    throw new ValidationError(
+      CommonReason.INVALID_INPUT,
+      "Lineup shape is malformed",
+    );
+  }
+
   const rosterIds = new Set(
     roster
       .filter((player) => player.id != null)

--- a/test/integration/lineup-roster-validation.itest.ts
+++ b/test/integration/lineup-roster-validation.itest.ts
@@ -1,0 +1,99 @@
+import type { GameRepositoryImpl } from "@/infrastructure/db/repositories/game.repository.mongo";
+import { container } from "@/infrastructure/di/inversify.config";
+import { TYPES } from "@/infrastructure/di/types";
+import {
+  POST as createSet,
+  PUT as updateSet,
+} from "@/app/api/games/[gameId]/sets/route";
+import { Types } from "mongoose";
+import { useFakeAuth } from "./support/auth";
+import { callRoute } from "./support/request";
+import { seedGame, type SeededGame } from "./support/seed";
+
+const options = { serve: "home", time: { start: "10:00", end: "" } };
+const nonRosterId = () => new Types.ObjectId().toString();
+
+const withGhostStarter = (seeded: SeededGame) => {
+  const lineup = structuredClone(seeded.lineup);
+  lineup.starting[0]!.id = nonRosterId();
+  return lineup;
+};
+
+describe("lineup roster validation on /api/games/:id/sets", () => {
+  let seeded: SeededGame;
+
+  beforeEach(async () => {
+    useFakeAuth();
+    seeded = await seedGame();
+  });
+
+  const repo = () => container.get<GameRepositoryImpl>(TYPES.GameRepository);
+
+  it("POST rejects a lineup referencing a non-roster player", async () => {
+    const res = await callRoute(createSet, {
+      gameId: seeded.gameId,
+      method: "POST",
+      query: { si: 0 },
+      body: { lineup: withGhostStarter(seeded), options },
+    });
+
+    expect(res.status).toBe(400);
+    const after = await repo().findById(seeded.gameId);
+    expect(after!.sets[0]).toBeUndefined();
+  });
+
+  it("POST persists a valid roster-derived lineup", async () => {
+    const res = await callRoute(createSet, {
+      gameId: seeded.gameId,
+      method: "POST",
+      query: { si: 0 },
+      body: { lineup: seeded.lineup, options },
+    });
+
+    expect(res.status).toBe(201);
+    const after = await repo().findById(seeded.gameId);
+    expect(after!.sets[0]!.lineups.home.starting[0]!.id).toBe(
+      seeded.playerIds[0],
+    );
+  });
+
+  it("PUT rejects a lineup referencing a non-roster player", async () => {
+    await callRoute(createSet, {
+      gameId: seeded.gameId,
+      method: "POST",
+      query: { si: 0 },
+      body: { lineup: seeded.lineup, options },
+    });
+
+    const res = await callRoute(updateSet, {
+      gameId: seeded.gameId,
+      method: "PUT",
+      query: { si: 0 },
+      body: { lineup: withGhostStarter(seeded), options },
+    });
+
+    expect(res.status).toBe(400);
+    const after = await repo().findById(seeded.gameId);
+    expect(after!.sets[0]!.lineups.home.starting[0]!.id).toBe(
+      seeded.playerIds[0],
+    );
+  });
+
+  it("PUT persists a valid roster-derived lineup", async () => {
+    await callRoute(createSet, {
+      gameId: seeded.gameId,
+      method: "POST",
+      query: { si: 0 },
+      body: { lineup: seeded.lineup, options },
+    });
+
+    const res = await callRoute(updateSet, {
+      gameId: seeded.gameId,
+      method: "PUT",
+      query: { si: 0 },
+      body: { lineup: seeded.lineup, options },
+    });
+
+    expect(res.status).toBe(200);
+  });
+});

--- a/test/integration/lineup-roster-validation.itest.ts
+++ b/test/integration/lineup-roster-validation.itest.ts
@@ -42,6 +42,19 @@ describe("lineup roster validation on /api/games/:id/sets", () => {
     expect(after!.sets[0]).toBeUndefined();
   });
 
+  it("POST rejects a malformed lineup shape without persisting", async () => {
+    const res = await callRoute(createSet, {
+      gameId: seeded.gameId,
+      method: "POST",
+      query: { si: 0 },
+      body: { lineup: { starting: "nope" }, options },
+    });
+
+    expect(res.status).toBe(400);
+    const after = await repo().findById(seeded.gameId);
+    expect(after!.sets[0]).toBeUndefined();
+  });
+
   it("POST persists a valid roster-derived lineup", async () => {
     const res = await callRoute(createSet, {
       gameId: seeded.gameId,


### PR DESCRIPTION
## Summary

When a set was created or updated, the client-supplied `lineup` was written straight onto `game.sets[i].lineups.home` with **no check** that the player ids in `starting` / `liberos` / `substitutes` (or their nested `sub`) reference real players on the team roster (`game.teams.home.players`). A buggy or malicious client could persist an arbitrary or malformed lineup — a trust-boundary input-validation gap.

## Fix

- Add a shared, pure entity-level guard `validateLineupPlayers(lineup, roster)` in `src/entities/game.ts`. It builds the allowed-id set from **non-null** roster ids (guest players carry a `null` id and are never valid targets), collects every referenced id across `starting` / `liberos` / `substitutes` and their nested `sub.id`, and throws when a **non-null** referenced id is absent from the roster. Null references (empty slots, unassigned subs) are skipped so valid lineups are unaffected.
- Call it from both `CreateSetUseCase` and `UpdateSetUseCase` (the latter only when a lineup is present) before persisting.

### Error class / status

Reuses the existing `ValidationError` (`code: "VALIDATION"`, `httpStatus: 400`) with `CommonReason.INVALID_INPUT` — an invalid lineup is a bad request, not a 404. This surfaces as HTTP **400** through the existing `withErrorHandler` wrapper. No new error class was needed.

### Layer choice: entity vs usecase

Placed in the **entity layer**, mirroring the existing `validatePlayerStatus` precedent in `src/entities/player.ts`. It is pure domain logic (a lineup must reference roster players) with no external dependencies, and living beside the `Lineup` and `Player` types lets both use cases share one definition instead of duplicating the check.

## Tests

- **Integration** (`test/integration/lineup-roster-validation.itest.ts`, real route handlers + mongodb-memory-server + fake auth): `POST /sets` and `PUT /sets` with a non-roster player id are rejected with 400 and nothing is persisted / the prior lineup is unchanged; valid roster-derived lineups still persist (201 / 200).
- **Unit** (`src/entities/__tests__/game.test.ts`): roster hit, roster miss, nested `sub` id miss, null-reference skipping, and the null-id guest never counting as a valid target.

## Verification

`pnpm verify:all` passes locally (format, typecheck, lint, 789 tests incl. the integration project, app build, service-worker assertion, blueprint build).

---

### 中文摘要

修補 set 建立／更新時的信任邊界輸入驗證漏洞：先前 client 送來的 `lineup` 未經檢查即寫入 `game.sets[i].lineups.home`，惡意或有 bug 的 client 可寫入不存在於隊伍名單的球員 id。新增 entity 層純函式 `validateLineupPlayers`（比照既有 `validatePlayerStatus` 慣例），驗證 `starting` / `liberos` / `substitutes` 及其巢狀 `sub` 中所有非 null 的球員 id 皆存在於名單（以非 null 名單 id 為允許集合，略過 null 空位與 guest），兩個 use case 皆於寫入前呼叫。無效名單回傳 `ValidationError`（HTTP 400）。含整合測試與單元測試，`pnpm verify:all` 全數通過。
