### PR TITLE
chore: add changeset for 0.14.4 [skip review]

### DIFF
--- a/.changeset/game-recording-fixes.md
+++ b/.changeset/game-recording-fixes.md
@@ -1,0 +1,21 @@
+---
+"volleybro": patch
+---
+
+### Fixed
+
+#### Record
+
+- Fix rally submission failing with a server error when the team roster includes a guest player
+- Fix a crash when recording the first rally of a set
+- Save lineup edits made in single-set settings and show a save confirmation
+
+#### UI
+
+- Add spacing between the fixed header and the court on the game recording screen
+
+### Security
+
+#### Record
+
+- Reject submitted set lineups that reference players not on the team roster


### PR DESCRIPTION
Changeset for the 0.14.4 patch release — the game-recording bug fixes and lineup-roster validation merged this cycle (#350, #352, #354, #355) had no changeset. Patch bump.

Changeset-only; no code change.

---

### 摘要（zh-tw）

補上 0.14.4 patch release 的 changeset（本輪的 game 記錄 bug 修復與 lineup roster 驗證）。純 changeset，無程式變更。