### PR TITLE
fix(game): show the court frame on mobile

### DIFF
--- a/.changeset/court-mobile-frame.md
+++ b/.changeset/court-mobile-frame.md
@@ -1,0 +1,9 @@
+---
+"volleybro": patch
+---
+
+### Fixed
+
+#### UI
+
+- Show the court's frame on mobile on the game recording screen, instead of it bleeding to the screen edge

--- a/.claude/skills/writing-changesets/README.md
+++ b/.claude/skills/writing-changesets/README.md
@@ -163,7 +163,7 @@ Use `pnpm changeset --empty` if CI requires a changeset file but the change has 
 ## FAQ
 
 **Q: What if I forgot to create a changeset on the feat branch?**
-A: Create it on dev before the PR to main. The changeset just needs to exist before `release:version` runs.
+A: Fallback only — create it on `dev` before the PR to `main` (it just needs to exist before `release:version` runs). Prefer fixing the habit: the changeset belongs in the original feat→dev PR, not batched at release time.
 
 **Q: Can I edit a changeset after creating it?**
 A: Yes. It's a plain markdown file in `.changeset/`. Edit and commit.

--- a/.claude/skills/writing-changesets/SKILL.md
+++ b/.claude/skills/writing-changesets/SKILL.md
@@ -11,38 +11,40 @@ This project uses `@changesets/cli` with a custom verbatim formatter and a postp
 
 ## Bundled Resources
 
-| File | When to read |
-| ------ | ------------- |
+| File             | When to read                                                                                                        |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------- |
 | `body-format.md` | When writing or reviewing changeset body content (heading rules, domain sub-headings, bullet style, omission rules) |
-| `README.md` | When you need the full end-to-end release workflow (branching model, CLI steps, toolchain architecture) |
+| `README.md`      | When you need the full end-to-end release workflow (branching model, CLI steps, toolchain architecture)             |
 
 ## When to Create a Changeset
 
-Create ONE changeset per spectra change, at `spectra:archive` time:
+Create ONE changeset per change, in the SAME feat/fix branch and PR to `dev` as the change itself — never deferred to release time:
 
 ```
-spectra:apply (implement) -> spectra:archive -> pnpm changeset -> commit
+implement -> pnpm changeset -> commit (same branch) -> PR to dev (carries the changeset)
 ```
 
-Skip the changeset if the change has zero user-visible impact (pure refactor, tests only, docs only).
+**Every PR to `dev` with user-visible impact MUST include its changeset.** Batching changesets onto `dev` right before the release is a last-resort fallback (see README FAQ), not the normal flow — it loses per-change context and risks a missed entry.
+
+Skip the changeset only if the change has zero user-visible impact (pure refactor, tests only, docs only); use `pnpm changeset --empty` if CI requires a file.
 
 ## CLI Quick Reference
 
-| Command | When | What it does |
-| --------- | ------ | -------------- |
-| `pnpm changeset` | After archive, on feat branch | Interactive: pick bump type, write body |
-| `pnpm changeset --empty` | CI requires changeset but no user impact | Creates empty changeset |
-| `pnpm changeset status` | Anytime | Shows pending changesets |
-| `pnpm release:version` | Run by CI (changesets.yml) on main; manual fallback only | Bumps version, updates CHANGELOG.md, deletes consumed changesets |
+| Command                  | When                                                     | What it does                                                     |
+| ------------------------ | -------------------------------------------------------- | ---------------------------------------------------------------- |
+| `pnpm changeset`         | After archive, on feat branch                            | Interactive: pick bump type, write body                          |
+| `pnpm changeset --empty` | CI requires changeset but no user impact                 | Creates empty changeset                                          |
+| `pnpm changeset status`  | Anytime                                                  | Shows pending changesets                                         |
+| `pnpm release:version`   | Run by CI (changesets.yml) on main; manual fallback only | Bumps version, updates CHANGELOG.md, deletes consumed changesets |
 
 **`commit` is `false`** -- all commands leave changes unstaged. You must `git add && git commit` manually.
 
 ## Bump Type Selection
 
-| Type | When |
-| ------ | ------ |
-| `patch` | Bug fixes, non-breaking improvements |
-| `minor` | New features, new APIs, backward-compatible additions |
+| Type    | When                                                                  |
+| ------- | --------------------------------------------------------------------- |
+| `patch` | Bug fixes, non-breaking improvements                                  |
+| `minor` | New features, new APIs, backward-compatible additions                 |
 | `major` | Breaking changes (removed APIs, changed behavior, migration required) |
 
 When in doubt, prefer `minor` for features, `patch` for fixes.
@@ -58,12 +60,12 @@ When writing the body at archive time, pull from the change's artifacts:
 
 ## Rationalization Table
 
-| Thought | Reality |
-| --------- | --------- |
-| "I'll add an Internal Changes section for completeness" | Omit entirely. There is no Internal Changes type. |
-| "Minor Changes / Bug Fixes are clearer headings" | Use the exact headings in `body-format.md`. No others. |
-| "The bug fix is more informative with the root cause" | Describe the observable fix, not the implementation. |
-| "Skipping `####` domains is fine for a short list" | Add domains whenever entries span multiple areas, regardless of count. |
+| Thought                                                           | Reality                                                                       |
+| ----------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| "I'll add an Internal Changes section for completeness"           | Omit entirely. There is no Internal Changes type.                             |
+| "Minor Changes / Bug Fixes are clearer headings"                  | Use the exact headings in `body-format.md`. No others.                        |
+| "The bug fix is more informative with the root cause"             | Describe the observable fix, not the implementation.                          |
+| "Skipping `####` domains is fine for a short list"                | Add domains whenever entries span multiple areas, regardless of count.        |
 | "The dep upgrade is worth mentioning even with no visible change" | Only include if it changes observable behavior or removes deprecated options. |
-| "This change is too small for a changeset" | If it has user-visible impact, it needs a changeset. Size doesn't matter. |
-| "I'll create the changeset later" | Create at archive time. Context is freshest then. |
+| "This change is too small for a changeset"                        | If it has user-visible impact, it needs a changeset. Size doesn't matter.     |
+| "I'll create the changeset later"                                 | Create at archive time. Context is freshest then.                             |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,7 @@ Components are organized by domain and purpose (features):
   - PR base branch: follow user-specified target; if unspecified and current branch is neither `main` nor `dev`, use `--base dev`.
 - For complex commits, include a body focused on **why**; "what" may be included as supporting context
 - Never use `spectra`, `openspec`, or any tooling name as the commit type or scope; use standard conventional commit types (`feat`, `fix`, `chore`, `docs`, etc.) with short scopes
+- **Changesets:** every PR to `dev` with user-visible impact MUST include its changeset (`.changeset/*.md`) in the same PR — created on the feat/fix branch alongside the change, not batched onto `dev` at release time. See the `writing-changesets` skill. Skip only for zero-user-impact changes (pure refactor, tests, docs, CI-internal).
 - **Judgment-type deletions require discussion first**: when a cleanup tool (knip, dead-code audits) or your own analysis flags source files for deletion beyond the explicitly requested change scope, list the candidates with per-file rationale and get confirmation before deleting. "Unreferenced in the import graph" is not sufficient evidence by itself — files may be documented API contracts (see `design-tokens.ts`), aliases of live database collections, or reserved for planned features.
 - In all Spectra artifacts, reference other changes by kebab-case name (e.g., `` `type-decoupling` change ``), never by letter labels (A, B, C)
 - Parked changes: automatically unpark and continue — no need to ask for confirmation

--- a/src/components/game/index.tsx
+++ b/src/components/game/index.tsx
@@ -67,7 +67,9 @@ const Game = ({ gameId, setIndex }: { gameId: string; setIndex: number }) => {
           <body> (fixed at the bottom), so pb reserves its idle peek height and
           the panel content never sits behind the peek. */}
       <div className="flex min-h-0 w-full flex-1 flex-col gap-1 pt-[calc(env(safe-area-inset-top)+5.75rem)] pb-21">
-        <div className="w-full shrink-0 overflow-hidden rounded-lg">
+        {/* inset only the court so its rounded frame clears the screen edge on
+            mobile; panel/header/drawer stay full-width */}
+        <div className="mx-1 shrink-0 overflow-hidden rounded-lg">
           <GameCourt gameId={gameId} mode="general" />
         </div>
         <GamePanel gameId={gameId} mode="general" className="min-h-0 flex-1" />
@@ -99,7 +101,7 @@ export function GameSkeleton() {
     <div className="flex h-full w-full max-w-160 flex-col items-center justify-start overflow-hidden">
       <GameHeader />
       <div className="flex min-h-0 w-full flex-1 flex-col gap-1 pt-[calc(env(safe-area-inset-top)+5.75rem)] pb-21">
-        <div className="w-full shrink-0 overflow-hidden rounded-lg">
+        <div className="mx-1 shrink-0 overflow-hidden rounded-lg">
           <LoadingCourt />
         </div>
         {/* mirrors GamePanel: progress bar + caption + moves grid, on bg-card */}


### PR DESCRIPTION
## What

- **Fix (C2)**: on mobile the court was full-bleed, so its rounded primary frame ran to the screen edge and read as missing. Inset only the court wrapper (drop `w-full`, add `mx-1` so it flex-stretches to full-minus-inset) in both the live layout and the skeleton. **Panel, header, and drawer-peek stay full-width** — this is the court-only inset (option B), avoiding the earlier `px-1` approach that misaligned court/panel against the full-width header/drawer.
- **Docs/process**: codify "changeset in the same feat→dev PR" in the `writing-changesets` skill (SKILL.md + README FAQ) and CLAUDE.md; add a changeset for the fix above.

## Verification note

C2 is a Tailwind-only layout change I **could not render** (the recording page is auth-gated — ATE-18). Please eyeball the **Vercel preview** on mobile: the court should show a small margin so its rounded frame is visible, while the panel/header/drawer remain flush. If the `mx-1` amount is off I'll adjust.

Relates to ATE-42.

---

### 摘要（zh-tw）

修 C2：手機上 court full-bleed、primary 外框貼邊而「消失」。改為只內縮 court wrapper（去 `w-full`、加 `mx-1` 靠 flex-stretch），panel/header/drawer 維持全寬（option B）。另把「changeset 要隨 feat→dev PR 附上」寫進 writing-changesets skill 與 CLAUDE.md，並附本次 changeset。C2 為 Tailwind 版面調整、無法自助截圖，請在 Vercel preview 目視確認內縮幅度。