### PR TITLE
fix(court): keep the court frame visible on narrow screens

### DIFF
--- a/.changeset/court-frame-mobile.md
+++ b/.changeset/court-frame-mobile.md
@@ -1,0 +1,9 @@
+---
+"volleybro": patch
+---
+
+### Fixed
+
+#### UI
+
+- Show the court's full frame on narrow screens, instead of it being cut off along the left and right edges

--- a/src/components/custom/court/index.tsx
+++ b/src/components/custom/court/index.tsx
@@ -51,7 +51,7 @@ export const Outside = ({
 
 export const Inside = ({ children }: { children?: React.ReactNode }) => {
   return (
-    <div className="relative grid aspect-square h-full max-h-[35vh] flex-9 gap-2 border-4 border-primary-foreground bg-[hsl(12.93,96.67%,76.47%)] px-2 py-[5%] [grid-template-areas:'z4_z3_z2''z5_z6_z1'] before:absolute before:top-0 before:min-h-[calc((100%-1rem)/3)] before:w-full before:border-b-4 before:border-background before:bg-destructive before:content-[''] dark:before:border-primary-foreground">
+    <div className="relative grid h-full max-h-[35vh] flex-9 gap-2 border-4 border-primary-foreground bg-[hsl(12.93,96.67%,76.47%)] px-2 py-[5%] [grid-template-areas:'z4_z3_z2''z5_z6_z1'] before:absolute before:top-0 before:min-h-[calc((100%-1rem)/3)] before:w-full before:border-b-4 before:border-background before:bg-destructive before:content-[''] dark:before:border-primary-foreground">
       {children}
     </div>
   );

--- a/src/components/game/index.tsx
+++ b/src/components/game/index.tsx
@@ -67,9 +67,7 @@ const Game = ({ gameId, setIndex }: { gameId: string; setIndex: number }) => {
           <body> (fixed at the bottom), so pb reserves its idle peek height and
           the panel content never sits behind the peek. */}
       <div className="flex min-h-0 w-full flex-1 flex-col gap-1 pt-[calc(env(safe-area-inset-top)+5.75rem)] pb-21">
-        {/* inset only the court so its rounded frame clears the screen edge on
-            mobile; panel/header/drawer stay full-width */}
-        <div className="mx-1 shrink-0 overflow-hidden rounded-lg">
+        <div className="w-full shrink-0 overflow-hidden rounded-lg">
           <GameCourt gameId={gameId} mode="general" />
         </div>
         <GamePanel gameId={gameId} mode="general" className="min-h-0 flex-1" />
@@ -101,7 +99,7 @@ export function GameSkeleton() {
     <div className="flex h-full w-full max-w-160 flex-col items-center justify-start overflow-hidden">
       <GameHeader />
       <div className="flex min-h-0 w-full flex-1 flex-col gap-1 pt-[calc(env(safe-area-inset-top)+5.75rem)] pb-21">
-        <div className="mx-1 shrink-0 overflow-hidden rounded-lg">
+        <div className="w-full shrink-0 overflow-hidden rounded-lg">
           <LoadingCourt />
         </div>
         {/* mirrors GamePanel: progress bar + caption + moves grid, on bg-card */}


### PR DESCRIPTION
## Root cause (measured, not guessed)

`Inside` carried `aspect-square`, deriving its **width from the height** that `max-h-[35vh]` caps. On a narrow screen that forced 268px + 72px (Outside) = 340px into a 327px content box — the row overflowed and ate `Court`'s `p-2`, so the frame survived only top/bottom.

Measured in Storybook at 375×812 (frame thickness, left/right/top/bottom):

| | left | right | top | bottom |
|---|---|---|---|---|
| before | **1px** | **2px** | 8px | 8px |
| after | **8px** | **8px** | 8px | 8px |

**Desktop is unaffected.** At 1280×800 flex already overrode the ratio (inside renders 520×264, not square); measurements are byte-identical before/after (8/8/8/8) — which is why desktop always looked correct.

## Change

- `custom/court/index.tsx`: drop `aspect-square` from `Inside`. The court stays **full-width — no content is inset or narrowed**.
- `game/index.tsx`: revert the earlier `mx-1` inset (it narrowed the court without fixing the frame) back to `w-full`.

Shared primitive, so the team lineup court gets the same fix; desktop there is likewise unchanged.

Relates to ATE-42.

---

### 摘要（zh-tw）

根因是 `Inside` 的 `aspect-square` 讓寬度由被 `max-h` 夾住的高度推導，窄螢幕下子元素溢出、吃掉 `Court` 的 `p-2`，外框只剩上下（實測左 1px／右 2px）。移除 `aspect-square` 後四邊皆為 8px，且 court 維持全寬、不內縮任何內容。桌機實測前後數值完全相同（flex 本就覆蓋該比例），故無回歸。並還原先前無效的 `mx-1`。