### PR TITLE
fix(court): restore the court frame on iOS and pad the panel

### DIFF
--- a/.changeset/court-frame-vertical.md
+++ b/.changeset/court-frame-vertical.md
@@ -1,0 +1,10 @@
+---
+"volleybro": patch
+---
+
+### Fixed
+
+#### UI
+
+- Show the court's frame along the top and bottom edges on iOS, where it was previously cut off
+- Add breathing room below the last row of recording buttons

--- a/.changeset/court-mobile-frame.md
+++ b/.changeset/court-mobile-frame.md
@@ -1,9 +1,0 @@
----
-"volleybro": patch
----
-
-### Fixed
-
-#### UI
-
-- Show the court's frame on mobile on the game recording screen, instead of it bleeding to the screen edge

--- a/src/components/custom/court/index.tsx
+++ b/src/components/custom/court/index.tsx
@@ -20,7 +20,7 @@ export const Court = ({
   return (
     <div
       className={cn(
-        "flex aspect-11/9 max-h-[35vh] w-full flex-row items-center justify-center bg-primary p-2",
+        "flex aspect-11/9 max-h-[35vh] w-full flex-row justify-center bg-primary p-2",
         className,
       )}
     >
@@ -39,7 +39,7 @@ export const Outside = ({
   return (
     <div
       className={cn(
-        "relative grid h-full max-h-[35vh] flex-1 grid-rows-3 gap-2 border-4 border-l-0 border-transparent pr-1 before:absolute before:top-0 before:min-h-[calc((100%-1rem)/3)] before:w-full before:border-b-4 before:border-dashed before:border-primary-foreground before:content-['']",
+        "relative grid flex-1 grid-rows-3 gap-2 border-4 border-l-0 border-transparent pr-1 before:absolute before:top-0 before:min-h-[calc((100%-1rem)/3)] before:w-full before:border-b-4 before:border-dashed before:border-primary-foreground before:content-['']",
         className,
       )}
     >
@@ -51,7 +51,7 @@ export const Outside = ({
 
 export const Inside = ({ children }: { children?: React.ReactNode }) => {
   return (
-    <div className="relative grid h-full max-h-[35vh] flex-9 gap-2 border-4 border-primary-foreground bg-[hsl(12.93,96.67%,76.47%)] px-2 py-[5%] [grid-template-areas:'z4_z3_z2''z5_z6_z1'] before:absolute before:top-0 before:min-h-[calc((100%-1rem)/3)] before:w-full before:border-b-4 before:border-background before:bg-destructive before:content-[''] dark:before:border-primary-foreground">
+    <div className="relative grid flex-9 gap-2 border-4 border-primary-foreground bg-[hsl(12.93,96.67%,76.47%)] px-2 py-[5%] [grid-template-areas:'z4_z3_z2''z5_z6_z1'] before:absolute before:top-0 before:min-h-[calc((100%-1rem)/3)] before:w-full before:border-b-4 before:border-background before:bg-destructive before:content-[''] dark:before:border-primary-foreground">
       {children}
     </div>
   );

--- a/src/components/game/index.tsx
+++ b/src/components/game/index.tsx
@@ -103,7 +103,7 @@ export function GameSkeleton() {
           <LoadingCourt />
         </div>
         {/* mirrors GamePanel: progress bar + caption + moves grid, on bg-card */}
-        <div className="flex min-h-0 w-full flex-1 flex-col items-center gap-2 overflow-hidden rounded-lg bg-card px-2 pt-2">
+        <div className="flex min-h-0 w-full flex-1 flex-col items-center gap-2 overflow-hidden rounded-lg bg-card px-2 py-2">
           <Skeleton className="h-1.5 w-full rounded-full" />
           <Skeleton className="h-4 w-40" />
           <div className="grid w-full flex-1 grid-cols-2 gap-2 pt-1">

--- a/src/components/game/panel/index.tsx
+++ b/src/components/game/panel/index.tsx
@@ -53,7 +53,7 @@ export const GamePanel = ({
   return (
     // min-h-0 lets the moves body below scroll within the panel instead of
     // overflowing past it onto the drawer peek.
-    <Panel className="min-h-0 gap-0 overflow-hidden rounded-lg">
+    <Panel className="min-h-0 gap-0 overflow-hidden rounded-lg pb-2">
       {status.panel !== "substitutes" && (
         <EntryProgressBar
           steps={steps}


### PR DESCRIPTION
## Root cause

The court's frame was missing along the **top and bottom** on iOS (sides were fine after #362).

`Inside`/`Outside` sized themselves with `h-full` (`height: 100%`) inside an `aspect-ratio` container. WebKit and Chromium resolve a percentage height in that situation against different boxes: on iOS the zones came out taller than the court's content box and painted over its `p-2`, hiding the frame top and bottom — exactly matching the zoomed screenshot (teal visible on the left, none above the coral, `Inside` border intact).

## Change

- `custom/court/index.tsx`: drop `h-full max-h-[35vh]` from `Inside`/`Outside` and `items-center` from `Court`, so flex stretches the zones to the content box. **No percentage height remains**, so both engines agree.
- `game/panel/index.tsx` + skeleton: add bottom padding so the last row of recording buttons isn't flush against the panel edge.

## Verification

Measured in Storybook at 393×852 (the real layout via `GameSkeleton`): frame **8/8/8/8** before and after, with `insideFitsContentBox: true` and no `h-full` remaining.

⚠️ **The WebKit difference itself I could not verify directly** — I only have Chromium, where the old markup already measured 8px. The fix removes the fragile percentage-height dependency rather than tuning a number, so the behaviour is now well-defined regardless. **Please confirm on the dev preview on iOS.**

Relates to ATE-42.

---

### 摘要（zh-tw）

court 上下缺框的根因：`Inside`/`Outside` 在 `aspect-ratio` 容器內用 `h-full`（百分比高度），WebKit 與 Chromium 解析基準不同，iOS 上高度超出 content box 而蓋掉 `p-2`，故上下無框、左右正常。改用 flex 拉伸至 content box，移除百分比高度依賴。另補 panel 底部 padding（最後一排按鈕不再貼齊邊緣），skeleton 同步。WebKit 差異我無法直接驗證（手上只有 Chromium），請在 iOS 的 dev preview 確認。