### PR TITLE
docs(agents): cut the bridge files to what the codebase cannot say itself

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,77 +1,25 @@
 # Delivery Workflow Bridge
 
-Read root [`WORKFLOW.md`](WORKFLOW.md) before intake, planning, implementation, review, handoff, or archive work. It is the canonical provider-neutral delivery contract; this file retains Codex and Antigravity mechanics and hard repository rules only.
-Repository-specific Matt Pocock adaptations live in `docs/agents/`. Read the issue-tracker, domain, Blueprint, and artifact-lifecycle adapters selected by `WORKFLOW.md`; never modify installed Matt skills to encode VolleyBro policy.
-Use the engineering skill selected by `WORKFLOW.md` for the current stage. Grilling and Wayfinder support discussion; specification and implementation-slice generation prepare approved work; Apply remains the same repository procedure whether a developer invokes it manually or Symphony invokes it after dispatch. Do not treat a tool-specific artifact system as a second lifecycle authority.
+VolleyBro is a volleyball team management and match recording PWA. The stack and its Clean Architecture layering are legible from `package.json` and the `src/` tree; current capability knowledge lives in `blueprint/content/features/`.
 
-## VolleyBro Introduction
+Read root [`WORKFLOW.md`](WORKFLOW.md) before intake, planning, implementation, review, handoff, or archive work. It is the canonical provider-neutral delivery contract and owns lifecycle sequencing and every human gate. Its repository adapters live in `docs/agents/` (issue-tracker, domain, Blueprint, artifact-lifecycle). This file holds only Codex and Antigravity mechanics and the rules that contract does not carry.
 
-VolleyBro is a volleyball team management and match recording web application built with **Clean Architecture** principles.
+## Gotchas
 
-### Technology Stack
+- Installed Matt Pocock skills and their `skills-lock.json` entries are vendor-managed. Never edit them to encode VolleyBro policy — that belongs in `docs/agents/`.
+- A tool-specific artifact system is never a second lifecycle authority.
+- **Judgment-type deletions need confirmation first.** When knip, a dead-code audit, or your own analysis flags files for deletion beyond the requested scope, list the candidates with per-file rationale and wait. "Unreferenced in the import graph" is not evidence on its own — a file may be a documented API contract (see `design-tokens.ts`), an alias of a live database collection, or reserved for planned work.
 
-- **Frontend**: Next.js 16+ (React 19), TypeScript
-- **UI**: Shadcn/UI components + Tailwind CSS
-- **State Management**: Redux Toolkit + SWR for data fetching + React Hook Form
-- **Database**: MongoDB with Mongoose ODM
-- **Authentication**: Better Auth with Google OAuth
-- **Dependency Injection**: InversifyJS
-- **PWA**: @serwist/turbopack (prerendered service-worker route) for Progressive Web App features
-- **Testing**: Jest, Storybook (to be refactored with optimal testing tools)
+## Writing
 
-### Clean Architecture Layers
+- `CONTRIBUTING.md` owns the commit format. Two rules it does not state: the body explains **why** ("what" is supporting context), and a tooling name (`spectra`, `openspec`) is never the type or scope.
+- Reference other changes by kebab-case slug (`` `type-decoupling` change ``), never by letter label.
+- Never hard-wrap prose you write or edit, in Markdown or in PR bodies. Nothing reflows it for you — `MD013` is off and Prettier leaves prose alone (`proseWrap` defaults to `preserve`) — so manual breaks survive and turn every later edit into a reflow diff. Docs predating this rule are still wrapped: match the file's existing width when editing one, and never reflow it wholesale as a side effect.
 
-1. **Domain Layer** (`src/entities/`)
-   - Core business entities: User, Team, Member, Game, Match, Set
-   - Pure business logic with no external dependencies
+## Pull requests
 
-2. **Application Layer** (`src/applications/`)
-   - `usecases/` - Business use cases (CreateGame, UpdateRally, etc.)
-   - `repositories/` - Abstract interfaces for data access
-   - `services/` - Abstract interfaces for external services
+[`WORKFLOW.md`](WORKFLOW.md) §5 owns the pre-PR gate. Work through it rather than a summary of it: review runs on the branch and repeats until both axes reach a fixed point, and developer acceptance plus the Archive commit both precede `gh pr create`.
 
-3. **Infrastructure Layer** (`src/infrastructure/`)
-   - `db/repositories/` - MongoDB repository implementations
-   - `services/` - Authentication and authorization services
-   - `di/` - InversifyJS dependency injection container
+Once the PR is open, CI is the only check to wait for. The automated review workflow was deleted in `6563e077`; the surviving `claude.yml` fires only on an explicit `@claude` mention, so no review arrives unprompted. Human comments are optional and the default merge path does not wait for them; if feedback does change durable knowledge, update the archived Blueprint Change and promoted authorities before merge.
 
-4. **Interface Layer** (`src/interface/controllers/`)
-   - API controllers that orchestrate use cases
-
-5. **Presentation Layer**
-   - `src/app/` - Next.js App Router (pages, layouts, API routes)
-   - `src/components/` - React UI components organized by domain
-
-### Component Organization
-
-Components are organized by domain and purpose (features):
-
-- `src/components/ui/` - Reusable UI components (Shadcn/UI based)
-- `src/components/custom/` - Project-specific reusable components
-- `src/components/auth/` - Authentication-related components
-- `src/components/team/` - Team management components
-- `src/components/game/` - Game recording, overview, and analysis components
-- `src/components/landing/` - Landing page components
-
-### Key Features
-
-1. **User Management**: Registration, authentication, profile management, team invitations
-2. **Team Management**: Create/edit teams, member management, lineup configuration
-3. **Game Recording**: Real-time game recording with detailed statistics
-4. **Data Analysis**: Game statistics, visualizations, and historical data
-
-**IMPORTANT**:
-
-- For complex commits, include a body focused on **why**; "what" may be included as supporting context
-- Never use `spectra`, `openspec`, or any tooling name as the commit type or scope; use standard conventional commit types (`feat`, `fix`, `chore`, `docs`, etc.) with short scopes
-- **Judgment-type deletions require discussion first**: when a cleanup tool (knip, dead-code audits) or your own analysis flags source files for deletion beyond the explicitly requested change scope, list the candidates with per-file rationale and get confirmation before deleting. "Unreferenced in the import graph" is not sufficient evidence by itself — files may be documented API contracts (see `design-tokens.ts`), aliases of live database collections, or reserved for planned features.
-- In all Change artifacts, reference other changes by kebab-case name (e.g., `` `type-decoupling` change ``), never by letter labels (A, B, C)
-
-### Pull request review
-
-The required independent code-review and fix rounds run before PR creation as defined by
-`WORKFLOW.md`. Human PR comments and their fix rounds are optional, and the default merge path does
-not wait for them. If optional feedback changes durable knowledge, update the archived Blueprint
-Change and promoted authorities before merge.
-
-See also: [`docs/testing-strategy.md`](docs/testing-strategy.md) for test guidelines, [`docs/maintenance-policy.md`](docs/maintenance-policy.md) for maintenance policies, and [`docs/design-system.md`](docs/design-system.md) for the color/elevation reference.
+See also: [`docs/testing-strategy.md`](docs/testing-strategy.md) for what to test at which layer, [`docs/maintenance-policy.md`](docs/maintenance-policy.md) for dependency and deprecation policy, [`docs/design-system.md`](docs/design-system.md) for colour and elevation tokens.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,77 +1,25 @@
 # Delivery Workflow Bridge
 
-Read root [`WORKFLOW.md`](WORKFLOW.md) before intake, planning, implementation, review, handoff, or archive work. It is the canonical provider-neutral delivery contract; this file retains Claude Code mechanics and hard repository rules only.
-Repository-specific Matt Pocock adaptations live in `docs/agents/`. Read the issue-tracker, domain, Blueprint, and artifact-lifecycle adapters selected by `WORKFLOW.md`; never modify installed Matt skills to encode VolleyBro policy.
-Use the engineering skill selected by `WORKFLOW.md` for the current stage. Grilling and Wayfinder support discussion; specification and implementation-slice generation prepare approved work; Apply remains the same repository procedure whether a developer invokes it manually or Symphony invokes it after dispatch. Do not treat a tool-specific artifact system as a second lifecycle authority.
+VolleyBro is a volleyball team management and match recording PWA. The stack and its Clean Architecture layering are legible from `package.json` and the `src/` tree; current capability knowledge lives in `blueprint/content/features/`.
 
-## VolleyBro Introduction
+Read root [`WORKFLOW.md`](WORKFLOW.md) before intake, planning, implementation, review, handoff, or archive work. It is the canonical provider-neutral delivery contract and owns lifecycle sequencing and every human gate. Its repository adapters live in `docs/agents/` (issue-tracker, domain, Blueprint, artifact-lifecycle). This file holds only Claude Code mechanics and the rules that contract does not carry.
 
-VolleyBro is a volleyball team management and match recording web application built with **Clean Architecture** principles.
+## Gotchas
 
-### Technology Stack
+- Installed Matt Pocock skills and their `skills-lock.json` entries are vendor-managed. Never edit them to encode VolleyBro policy — that belongs in `docs/agents/`.
+- A tool-specific artifact system is never a second lifecycle authority.
+- **Judgment-type deletions need confirmation first.** When knip, a dead-code audit, or your own analysis flags files for deletion beyond the requested scope, list the candidates with per-file rationale and wait. "Unreferenced in the import graph" is not evidence on its own — a file may be a documented API contract (see `design-tokens.ts`), an alias of a live database collection, or reserved for planned work.
 
-- **Frontend**: Next.js 16+ (React 19), TypeScript
-- **UI**: Shadcn/UI components + Tailwind CSS
-- **State Management**: Redux Toolkit + SWR for data fetching + React Hook Form
-- **Database**: MongoDB with Mongoose ODM
-- **Authentication**: Better Auth with Google OAuth
-- **Dependency Injection**: InversifyJS
-- **PWA**: @serwist/turbopack (prerendered service-worker route) for Progressive Web App features
-- **Testing**: Jest, Storybook (to be refactored with optimal testing tools)
+## Writing
 
-### Clean Architecture Layers
+- `CONTRIBUTING.md` owns the commit format. Two rules it does not state: the body explains **why** ("what" is supporting context), and a tooling name (`spectra`, `openspec`) is never the type or scope.
+- Reference other changes by kebab-case slug (`` `type-decoupling` change ``), never by letter label.
+- Never hard-wrap prose you write or edit, in Markdown or in PR bodies. Nothing reflows it for you — `MD013` is off and Prettier leaves prose alone (`proseWrap` defaults to `preserve`) — so manual breaks survive and turn every later edit into a reflow diff. Docs predating this rule are still wrapped: match the file's existing width when editing one, and never reflow it wholesale as a side effect.
 
-1. **Domain Layer** (`src/entities/`)
-   - Core business entities: User, Team, Member, Game, Match, Set
-   - Pure business logic with no external dependencies
+## Pull requests
 
-2. **Application Layer** (`src/applications/`)
-   - `usecases/` - Business use cases (CreateGame, UpdateRally, etc.)
-   - `repositories/` - Abstract interfaces for data access
-   - `services/` - Abstract interfaces for external services
+[`WORKFLOW.md`](WORKFLOW.md) §5 owns the pre-PR gate. Work through it rather than a summary of it: review runs on the branch and repeats until both axes reach a fixed point, and developer acceptance plus the Archive commit both precede `gh pr create`.
 
-3. **Infrastructure Layer** (`src/infrastructure/`)
-   - `db/repositories/` - MongoDB repository implementations
-   - `services/` - Authentication and authorization services
-   - `di/` - InversifyJS dependency injection container
+Once the PR is open, CI is the only check to wait for. The automated review workflow was deleted in `6563e077`; the surviving `claude.yml` fires only on an explicit `@claude` mention, so no review arrives unprompted. Human comments are optional and the default merge path does not wait for them; if feedback does change durable knowledge, update the archived Blueprint Change and promoted authorities before merge.
 
-4. **Interface Layer** (`src/interface/controllers/`)
-   - API controllers that orchestrate use cases
-
-5. **Presentation Layer**
-   - `src/app/` - Next.js App Router (pages, layouts, API routes)
-   - `src/components/` - React UI components organized by domain
-
-### Component Organization
-
-Components are organized by domain and purpose (features):
-
-- `src/components/ui/` - Reusable UI components (Shadcn/UI based)
-- `src/components/custom/` - Project-specific reusable components
-- `src/components/auth/` - Authentication-related components
-- `src/components/team/` - Team management components
-- `src/components/game/` - Game recording, overview, and analysis components
-- `src/components/landing/` - Landing page components
-
-### Key Features
-
-1. **User Management**: Registration, authentication, profile management, team invitations
-2. **Team Management**: Create/edit teams, member management, lineup configuration
-3. **Game Recording**: Real-time game recording with detailed statistics
-4. **Data Analysis**: Game statistics, visualizations, and historical data
-
-**IMPORTANT**:
-
-- For complex commits, include a body focused on **why**; "what" may be included as supporting context
-- Never use `spectra`, `openspec`, or any tooling name as the commit type or scope; use standard conventional commit types (`feat`, `fix`, `chore`, `docs`, etc.) with short scopes
-- **Judgment-type deletions require discussion first**: when a cleanup tool (knip, dead-code audits) or your own analysis flags source files for deletion beyond the explicitly requested change scope, list the candidates with per-file rationale and get confirmation before deleting. "Unreferenced in the import graph" is not sufficient evidence by itself — files may be documented API contracts (see `design-tokens.ts`), aliases of live database collections, or reserved for planned features.
-- In all Change artifacts, reference other changes by kebab-case name (e.g., `` `type-decoupling` change ``), never by letter labels (A, B, C)
-
-### Pull request review
-
-The required independent code-review and fix rounds run before PR creation as defined by
-`WORKFLOW.md`. Human PR comments and their fix rounds are optional, and the default merge path does
-not wait for them. If optional feedback changes durable knowledge, update the archived Blueprint
-Change and promoted authorities before merge.
-
-See also: [`docs/testing-strategy.md`](docs/testing-strategy.md) for test guidelines, [`docs/maintenance-policy.md`](docs/maintenance-policy.md) for maintenance policies, and [`docs/design-system.md`](docs/design-system.md) for the color/elevation reference.
+See also: [`docs/testing-strategy.md`](docs/testing-strategy.md) for what to test at which layer, [`docs/maintenance-policy.md`](docs/maintenance-policy.md) for dependency and deprecation policy, [`docs/design-system.md`](docs/design-system.md) for colour and elevation tokens.


### PR DESCRIPTION
## Summary

Cuts `CLAUDE.md` and `AGENTS.md` from 77 lines to 25 each, applying the principles in [The new rules of context engineering for Claude 5 generation models](https://claude.com/blog/the-new-rules-of-context-engineering-for-claude-5-generation-models), and pins two rules that were being missed.

## Problem

Both bridge files had grown into a second description of the repository. The technology stack, the Clean Architecture layer list, the component tree, and the feature inventory together made up roughly 55 of 77 lines — all of it already legible from `package.json`, the `src/` tree, and `blueprint/content/features/`. It cost context on every session while teaching nothing, and it rotted silently whenever the real structure moved.

Separately, `WORKFLOW.md` §5 already required an independent `code-review` pass on the branch before the PR opens, but both bridge files only described it in the abstract, so it read as something that happens rather than a step to perform.

## Changes

- Remove what the codebase already says: stack, layers, component organisation, feature list
- Keep what it cannot: the `WORKFLOW.md` pointer, the vendor-managed skills boundary, the judgment-type deletion rule and its burn history, commit and prose conventions
- Point the PR section at `WORKFLOW.md` §5 instead of restating it, naming the constraints a summary tends to drop — review repeats to a fixed point, and developer acceptance plus the Archive commit both precede `gh pr create`
- Record that the automated review workflow was deleted in `6563e077` and that the surviving `claude.yml` only fires on an explicit `@claude` mention, so CI is the only post-PR check to wait for
- Ban hard-wrapped prose, which nothing else enforces: `MD013` is off and Prettier leaves prose alone, so manual breaks survive and turn later edits into reflow diffs

`WORKFLOW.md` is unchanged — it already carried the review rule, and prose-wrapping is an authoring mechanic rather than part of the delivery contract.

## On splitting the PR rules into their own file

Considered and rejected. Progressive disclosure suits guidance that is long and only sometimes relevant; these rules are now two paragraphs and apply every single time a PR is opened. The long form already lives in `WORKFLOW.md` §5, so a third file would only add a hop that has to be remembered — which is the exact failure mode this change is fixing.

## Verification

- Two rounds of independent two-axis `code-review`. Round 1 found the PR section had copied `WORKFLOW.md` §5 rather than pointing at it, and had silently dropped the fixed-point, acceptance, and Archive constraints; round 2 confirmed both axes clean, with three wording fixes applied after it
- Every factual claim checked against the repository: `6563e077` deletes `claude-code-review.yml`, all four `if:` branches in `claude.yml` require `@claude`, `MD013: false` in `.markdownlint.jsonc`, `.prettierrc` sets no `proseWrap`, and `CONTRIBUTING.md` states neither retained commit rule
- `CLAUDE.md` and `AGENTS.md` verified byte-identical except the one clause naming the provider
- `pnpm verify:all` passes — 100 suites / 784 tests, app build, `assert-sw: OK`, blueprint build

## Notes

No changeset: agent instruction files only, no app behaviour changes.

---

### 摘要（zh-TW）

依 Claude 5 context engineering 原則精簡 `CLAUDE.md` 與 `AGENTS.md`，各從 77 行降到 25 行。原本 77 行中約 55 行是 codebase 自己就看得到的資訊——技術棧、Clean Architecture 分層、component 樹、功能清單——它們每次 session 都佔 context 卻沒有教到任何東西，而且真實結構一改就默默過期。保留的是無法推導的部分：`WORKFLOW.md` 指標、vendor-managed skills 邊界、judgment-type 刪除規則與其前科、commit 與 prose 慣例。

同時釘住兩條一直被漏掉的規則：PR 前必須在 branch 上跑獨立 `code-review`（改成指向 `WORKFLOW.md` §5 而非重述，並點名摘要容易吞掉的 fixed point、developer acceptance 與 Archive commit），以及 PR 開啟後只需等 CI（自動 review workflow 已於 `6563e077` 刪除，殘存的 `claude.yml` 僅在 `@claude` mention 時觸發）。另新增禁止 prose 硬換行——`MD013` 已關閉且 Prettier 不會重排 prose，沒有任何工具在管這件事。

`WORKFLOW.md` 未修改：review 規則它本來就有，而換行屬於撰寫機制而非交付契約。PR 規則經評估**不**獨立成檔案——它只剩兩段且每次開 PR 都會用到，長篇版本已在 §5，多開一個檔案只會多一個必須記得去讀的跳轉，而那正是這次要修的失效模式。

已跑兩輪獨立雙軸 code-review，所有事實斷言均對照 repo 查證，`pnpm verify:all` 通過。純 agent 指令檔變更，未附 changeset。
