### PR TITLE
fix(game): record rallies again by storing an absent player reference as null

### DIFF
--- a/.changeset/rally-empty-player-ref.md
+++ b/.changeset/rally-empty-player-ref.md
@@ -1,0 +1,11 @@
+---
+"volleybro": patch
+---
+
+### Fixed
+
+#### Record
+
+- Record rallies again: every submission failed with a "not found" error, because a point won against the opponent has no player to name on their side
+- Stop showing the recording court for a set that was never started, where every rally submitted from it was rejected
+- Offer the correct next set when starting a new one from a set that is not the last

--- a/src/applications/usecases/game/create-set.usecase.ts
+++ b/src/applications/usecases/game/create-set.usecase.ts
@@ -59,7 +59,9 @@ export class CreateSetUseCase implements ICreateSetUseCase {
     const activePlayerIds = new Set([...startingPlayers, ...liberoPlayers]);
 
     game.teams.home.players.forEach((player) => {
-      // Guest players have a null id and never appear in a lineup's active set.
+      // No product path puts a null id on the roster, but POST /api/games
+      // stores the squad it is handed unvalidated, so skip one rather than
+      // throwing on it.
       if (player.id && activePlayerIds.has(player.id.toString())) {
         player.stats[params.setIndex] = new PlayerStatsClass();
       }

--- a/src/components/game/__tests__/summary-drawer.test.tsx
+++ b/src/components/game/__tests__/summary-drawer.test.tsx
@@ -26,7 +26,7 @@ jest.mock("@/hooks/use-data", () => ({
 }));
 jest.mock("@/components/game/preview", () => ({
   ...jest.requireActual("@/components/game/preview"),
-  useEntryDraftPreview: () => ({ inProgress: false, isEditing: false }),
+  useEntryDraftPreview: () => ({ hasPreview: false, isEditing: false }),
 }));
 
 const players: GamePlayerView[] = [

--- a/src/components/game/court.tsx
+++ b/src/components/game/court.tsx
@@ -27,7 +27,7 @@ export const GameCourt = ({
   );
   const { starting, liberos } = useLineup(gameId, setIndex, status);
 
-  if (status.inProgress === false) {
+  if (status.isSetInProgress === false) {
     return (
       <Court>
         <Outside className="inner">

--- a/src/components/game/index.tsx
+++ b/src/components/game/index.tsx
@@ -137,6 +137,11 @@ const Interval = ({
   gameId: string;
   setIndex: number;
 }) => {
+  const { game } = useGame(gameId);
+  // SetOptions only treats `sets.length` as a new set, and the viewed set is
+  // not always the last one.
+  const nextSetIndex = game?.sets.length ?? setIndex + 1;
+
   return (
     <>
       <GameHeader gameId={gameId} />
@@ -166,7 +171,7 @@ const Interval = ({
               新的一局
             </Button>
           </DialogTrigger>
-          <SetOptions gameId={gameId} setIndex={setIndex + 1} />
+          <SetOptions gameId={gameId} setIndex={nextSetIndex} />
         </Dialog>
       </div>
     </>

--- a/src/components/game/index.tsx
+++ b/src/components/game/index.tsx
@@ -54,7 +54,7 @@ const Game = ({ gameId, setIndex }: { gameId: string; setIndex: number }) => {
     return <GameSkeleton />;
   }
 
-  if (!general.status.inProgress) {
+  if (!general.status.isSetInProgress) {
     return <Interval gameId={gameId} setIndex={setIndex} />;
   }
 

--- a/src/components/game/preview.tsx
+++ b/src/components/game/preview.tsx
@@ -101,11 +101,11 @@ export const useEntryDraftPreview = (
   const { setIndex } = useAppSelector((state) => state.game);
   const {
     entryDraft: draft,
-    status: { inProgress, entryIndex },
+    status: { isSetInProgress, entryIndex },
   } = useAppSelector((state) => state.game[mode]);
 
   // a rolled-back optimistic mutate can transiently leave game undefined
-  if (!game || !inProgress) return { inProgress: false as const };
+  if (!game || !isSetInProgress) return { hasPreview: false as const };
 
   const { players } = game.teams.home;
   const previousEntry =
@@ -142,14 +142,14 @@ export const useEntryDraftPreview = (
   const entry = isEditing || entryIndex === 0 ? draftEntry : previousEntry;
 
   // first entry, before any input: nothing to preview
-  if (!entry) return { inProgress: false as const };
+  if (!entry) return { hasPreview: false as const };
 
   const { submittable } = getEntryProgress(draft);
   // === true so a valid num === 0 is not read as incomplete
   const isComplete = submittable === true;
 
   return {
-    inProgress: true as const,
+    hasPreview: true as const,
     entry,
     previousEntry,
     players,
@@ -173,7 +173,7 @@ export const GamePreview = ({
   className?: string;
 }) => {
   const preview = useEntryDraftPreview(gameId, mode);
-  if (!preview.inProgress) return null;
+  if (!preview.hasPreview) return null;
   const { entry, previousEntry, players, isEditing, isComplete, entryIndex } =
     preview;
 

--- a/src/components/game/summary-drawer.tsx
+++ b/src/components/game/summary-drawer.tsx
@@ -13,7 +13,7 @@ import { useState } from "react";
 
 export type SummaryDrawerState = "idle" | "expanded";
 
-/** Props PreviewCard needs, minus `inProgress` (the caller already checked it). */
+/** Props PreviewCard needs, minus `hasPreview` (the caller already checked it). */
 export type SummaryDrawerPreview = {
   entry: EntryView;
   previousEntry: EntryView | undefined;
@@ -267,7 +267,7 @@ export const SummaryDrawer = ({
   // Only the uncommitted draft is the distinct Preview bar (while recording);
   // when idle the newest committed entry is simply the top row, so it appears
   // in the list rather than as a separate preview.
-  const recording = preview.inProgress && preview.isEditing;
+  const recording = preview.hasPreview && preview.isEditing;
   const listEntries = entries.map((entry, index) => ({ entry, index }));
 
   const handleEntryClick = (entryIndex: number) => {
@@ -281,7 +281,7 @@ export const SummaryDrawer = ({
       totalEntries={entries.length}
       players={players}
       state={state}
-      preview={recording && preview.inProgress ? preview : undefined}
+      preview={recording && preview.hasPreview ? preview : undefined}
       onToggle={onToggle}
       onSubmit={onSubmit}
       onEntryClick={handleEntryClick}

--- a/src/entities/__tests__/game.test.ts
+++ b/src/entities/__tests__/game.test.ts
@@ -145,12 +145,12 @@ describe("validateLineupPlayers", () => {
     ).toThrow(ValidationError);
   });
 
-  it("never treats a null-id guest on the roster as a valid target", () => {
-    const rosterWithGuest = [player("a"), player(null)];
+  it('never lets the literal "null" reference a null roster id', () => {
+    const rosterWithNullId = [player("a"), player(null)];
     expect(() =>
       validateLineupPlayers(
         lineup({ starting: [{ id: "a" }, { id: "null" }] }),
-        rosterWithGuest,
+        rosterWithNullId,
       ),
     ).toThrow(ValidationError);
   });

--- a/src/entities/game.ts
+++ b/src/entities/game.ts
@@ -92,8 +92,9 @@ export type Player = {
 
 /**
  * Validate that every player id referenced by a lineup exists on the roster.
- * Guest players carry a null id, so only non-null roster ids are allowed
- * targets; null references in the lineup are empty slots and are skipped.
+ * A null lineup reference is an unfilled slot and is skipped. A null roster id
+ * is dropped rather than stringified, so a lineup cannot reach it by naming the
+ * literal "null".
  * Throws ValidationError if the lineup shape is malformed or a referenced id
  * is not on the roster.
  */

--- a/src/infrastructure/db/repositories/__tests__/repository-helpers.test.ts
+++ b/src/infrastructure/db/repositories/__tests__/repository-helpers.test.ts
@@ -3,20 +3,29 @@ import {
   NotFoundError,
   TransientError,
   UnexpectedError,
+  ValidationError,
 } from "@/entities/errors";
 import { translateRepositoryError } from "@/infrastructure/db/repositories/repository-helpers.mongo";
 
 describe("Repository error translation", () => {
-  describe("CastError → NotFoundError", () => {
-    it("translates Mongoose CastError to NotFoundError", () => {
+  describe("CastError", () => {
+    it("translates a CastError on _id to NotFoundError", () => {
       const castError = Object.assign(
         new Error("Cast to ObjectId failed for value bad-id"),
-        {
-          name: "CastError",
-        },
+        { name: "CastError", path: "_id" },
       );
       const result = translateRepositoryError(castError);
       expect(result).toBeInstanceOf(NotFoundError);
+    });
+
+    it("translates a CastError on any other path to ValidationError", () => {
+      const castError = Object.assign(
+        new Error('Cast to embedded failed at path "sets"'),
+        { name: "CastError", path: "sets" },
+      );
+      const result = translateRepositoryError(castError);
+      expect(result).toBeInstanceOf(ValidationError);
+      expect(result.httpStatus).toBe(400);
     });
   });
 

--- a/src/infrastructure/db/repositories/game.repository.mongo.ts
+++ b/src/infrastructure/db/repositories/game.repository.mongo.ts
@@ -151,16 +151,24 @@ export class GameRepositoryImpl implements IGameRepository {
 
   // --- write mapping: domain id -> persisted playerId (Mongoose casts) ---
 
+  /** "No player" arrives as `""` as often as `null`, and only `null` casts. */
+  private toPlayerRef(id: string | null | undefined) {
+    return id || null;
+  }
+
   private mapLineupPlayerWrite(p: {
     id?: string | null;
     position?: string;
     sub?: { id?: string; entryIndex?: { in?: number; out?: number } };
   }) {
     return {
-      playerId: p?.id ?? null,
+      playerId: this.toPlayerRef(p?.id),
       position: p?.position,
       sub: p?.sub
-        ? { playerId: p.sub.id ?? null, entryIndex: p.sub.entryIndex }
+        ? {
+            playerId: this.toPlayerRef(p.sub.id),
+            entryIndex: p.sub.entryIndex,
+          }
         : undefined,
     };
   }
@@ -191,7 +199,7 @@ export class GameRepositoryImpl implements IGameRepository {
     snapshot: { id?: string | null } & Record<string, unknown>,
   ) {
     const { id, ...rest } = snapshot;
-    return { ...rest, playerId: id ?? null };
+    return { ...rest, playerId: this.toPlayerRef(id) };
   }
 
   private mapTeamWrite(
@@ -234,19 +242,33 @@ export class GameRepositoryImpl implements IGameRepository {
     if (!d?.player) return d;
     return {
       ...d,
-      player: { playerId: d.player.id ?? null, zone: d.player.zone },
+      player: {
+        playerId: this.toPlayerRef(d.player.id),
+        zone: d.player.zone,
+      },
     };
   }
 
   private mapEntryWrite(entry: Record<string, unknown> & { type?: EntryType }) {
-    // Substitution `players.in/out` keep their field names; Mongoose casts the
-    // hex strings to ObjectId on the declared paths. Only rally detail needs the
-    // `player.id -> player.playerId` rename.
     if (entry?.type === EntryType.RALLY) {
       return {
         ...entry,
         home: this.mapRallyDetailWrite(entry.home),
         away: this.mapRallyDetailWrite(entry.away),
+      };
+    }
+    // Substitution keeps the `players.in/out` field names; only the ids need
+    // the same empty-string collapse as every other ObjectId path.
+    if (entry?.type === EntryType.SUBSTITUTION) {
+      const players = entry.players as
+        { in?: string | null; out?: string | null } | undefined;
+      if (!players) return entry;
+      return {
+        ...entry,
+        players: {
+          in: this.toPlayerRef(players.in),
+          out: this.toPlayerRef(players.out),
+        },
       };
     }
     return entry;

--- a/src/infrastructure/db/repositories/repository-helpers.mongo.ts
+++ b/src/infrastructure/db/repositories/repository-helpers.mongo.ts
@@ -4,6 +4,7 @@ import {
   NotFoundError,
   TransientError,
   UnexpectedError,
+  ValidationError,
   CommonReason,
 } from "@/entities/errors";
 
@@ -16,9 +17,18 @@ export function translateRepositoryError(error: unknown): AppError {
   if (error instanceof AppError) return error;
   if (error instanceof Error) {
     if (error.name === "CastError") {
-      return new NotFoundError(
-        CommonReason.RESOURCE_NOT_FOUND,
-        "The requested resource was not found",
+      // Only an uncastable `_id` is a lookup miss; anywhere else it is the
+      // payload being written that the database cannot store.
+      if ((error as { path?: unknown }).path === "_id") {
+        return new NotFoundError(
+          CommonReason.RESOURCE_NOT_FOUND,
+          "The requested resource was not found",
+          error.message,
+        );
+      }
+      return new ValidationError(
+        CommonReason.INVALID_INPUT,
+        "The request contains a value the database cannot store",
         error.message,
       );
     }

--- a/src/lib/features/game/game-slice.ts
+++ b/src/lib/features/game/game-slice.ts
@@ -1,6 +1,6 @@
 import { EntryType, Side } from "@/entities/game";
 import {
-  gamePhaseHelper,
+  getSetPhase,
   getPreviousScores,
   getServingStatus,
 } from "@/lib/features/game/helpers";
@@ -22,7 +22,7 @@ const statusState: ReduxStatus = {
   scores: { home: 0, away: 0 },
   entryIndex: 0,
   isServing: false,
-  inProgress: false,
+  isSetInProgress: false,
   isSetPoint: false,
   panel: "home",
 };
@@ -64,7 +64,7 @@ const initialize: CaseReducer<
   const { game, setIndex } = action.payload;
   const set = game.sets[setIndex];
   const entryIndex = set?.entries?.length || 0;
-  const { inProgress, isSetPoint } = gamePhaseHelper(
+  const { isSetInProgress, isSetPoint } = getSetPhase(
     game,
     setIndex,
     entryIndex,
@@ -77,7 +77,7 @@ const initialize: CaseReducer<
     scores: getPreviousScores(set?.entries, entryIndex),
     entryIndex,
     isServing,
-    inProgress,
+    isSetInProgress,
     isSetPoint,
     panel: "home" as ReduxStatus["panel"],
   };
@@ -154,9 +154,9 @@ const setEntryDraftAwayMove: CaseReducer<
 
 const confirmEntryDraftRally: CaseReducer<
   ReduxGameState,
-  PayloadAction<{ inProgress: boolean; isSetPoint: boolean }>
+  PayloadAction<{ isSetInProgress: boolean; isSetPoint: boolean }>
 > = (state, action) => {
-  const { inProgress, isSetPoint } = action.payload;
+  const { isSetInProgress, isSetPoint } = action.payload;
   const { mode } = state;
   const { entryIndex } = state[mode].status;
 
@@ -168,7 +168,7 @@ const confirmEntryDraftRally: CaseReducer<
     },
     entryIndex: entryIndex + 1,
     isServing: state[mode].entryDraft.win ?? false,
-    inProgress,
+    isSetInProgress,
     isSetPoint,
     panel: "home",
   };
@@ -259,7 +259,7 @@ const setEditingEntryStatus: CaseReducer<
   const set = game.sets[setIndex];
   const entry = set?.entries[entryIndex];
   if (!entry) return;
-  const { inProgress, isSetPoint } = gamePhaseHelper(
+  const { isSetInProgress, isSetPoint } = getSetPhase(
     game,
     setIndex,
     entryIndex,
@@ -291,7 +291,7 @@ const setEditingEntryStatus: CaseReducer<
     isServing: getServingStatus(set, entryIndex),
     scores: getPreviousScores(set?.entries, entryIndex),
     entryIndex,
-    inProgress: inProgress,
+    isSetInProgress,
     isSetPoint: isSetPoint,
     panel: entry.type === EntryType.SUBSTITUTION ? "substitutes" : "away",
   };

--- a/src/lib/features/game/helpers/index.ts
+++ b/src/lib/features/game/helpers/index.ts
@@ -1,8 +1,8 @@
-import { gamePhaseHelper } from "@/lib/features/game/helpers/queries/game-phase.helper";
 import { getPreviousRally } from "@/lib/features/game/helpers/queries/previous-rally.helper";
 import { getPreviousScores } from "@/lib/features/game/helpers/queries/previous-scores.helper";
 import { getServingStatus } from "@/lib/features/game/helpers/queries/serving-status.helper";
 import { getSetLineup } from "@/lib/features/game/helpers/queries/set-lineup.helper";
+import { getSetPhase } from "@/lib/features/game/helpers/queries/set-phase.helper";
 
 import {
   createRallyHelper,
@@ -13,10 +13,10 @@ import { createSubstitutionHelper } from "@/lib/features/game/helpers/optimistic
 export {
   createRallyHelper,
   createSubstitutionHelper,
-  gamePhaseHelper,
   getPreviousRally,
   getPreviousScores,
   getServingStatus,
   getSetLineup,
+  getSetPhase,
   updateRallyHelper,
 };

--- a/src/lib/features/game/helpers/optimistic/rally.helper.ts
+++ b/src/lib/features/game/helpers/optimistic/rally.helper.ts
@@ -61,8 +61,8 @@ export const updateRallyHelper = (
   return { game, phase };
 };
 
-// A roster guest carries a null id and a rally scored against the opponent
-// carries no player at all, so "nobody" must never match a squad member.
+// A rally can name no player, and "nobody" must not match a squad member whose
+// own id is absent.
 const findScorer = (game: GameView, rally: RallyView) => {
   const id = rally.home.player?.id;
   return id ? game.teams.home.players.find((player) => player.id === id) : null;

--- a/src/lib/features/game/helpers/optimistic/rally.helper.ts
+++ b/src/lib/features/game/helpers/optimistic/rally.helper.ts
@@ -61,16 +61,20 @@ export const updateRallyHelper = (
   return { game, phase };
 };
 
+// A roster guest carries a null id and a rally scored against the opponent
+// carries no player at all, so "nobody" must never match a squad member.
+const findScorer = (game: GameView, rally: RallyView) => {
+  const id = rally.home.player?.id;
+  return id ? game.teams.home.players.find((player) => player.id === id) : null;
+};
+
 const discardOriginalStats = (
   game: GameView,
   setIndex: number,
   originalRally: RallyView,
 ) => {
   const { win, home, away } = originalRally;
-  const homePlayerIndex = game.teams.home.players.findIndex(
-    (player) => player.id === home.player?.id,
-  );
-  const homePlayer = game.teams.home.players[homePlayerIndex];
+  const homePlayer = findScorer(game, originalRally);
   const homeTeam = game.teams.home;
   const awayTeam = game.teams.away;
 
@@ -102,10 +106,7 @@ const updateStats = (
   entryDraft: RallyView,
 ) => {
   const { win, home, away } = entryDraft;
-  const homePlayerIndex = game.teams.home.players.findIndex(
-    (player) => player.id === home.player?.id,
-  );
-  const homePlayer = game.teams.home.players[homePlayerIndex];
+  const homePlayer = findScorer(game, entryDraft);
   const homeTeam = game.teams.home;
   const awayTeam = game.teams.away;
 

--- a/src/lib/features/game/helpers/optimistic/rally.helper.ts
+++ b/src/lib/features/game/helpers/optimistic/rally.helper.ts
@@ -1,5 +1,5 @@
 import { EntryType, MoveType } from "@/entities/game";
-import { gamePhaseHelper, getServingStatus } from "@/lib/features/game/helpers";
+import { getSetPhase, getServingStatus } from "@/lib/features/game/helpers";
 import type { GameView, RallyView } from "@/lib/features/game/types";
 
 type StatEntry = { success: number; error: number };
@@ -151,11 +151,11 @@ const processGamePhase = (
   entryIndex: number,
   entryDraft: RallyView,
 ) => {
-  const phase = gamePhaseHelper(game, setIndex, entryIndex + 1);
+  const phase = getSetPhase(game, setIndex, entryIndex + 1);
   // setIndex is the active set being processed; guaranteed in bounds
   const set = game.sets[setIndex]!;
 
-  if (phase.inProgress) {
+  if (phase.isSetInProgress) {
     // Reset win status if the set/game is still in progress
     if (typeof set.win === "boolean") {
       set.win = null;

--- a/src/lib/features/game/helpers/optimistic/test/rally.helper.test.ts
+++ b/src/lib/features/game/helpers/optimistic/test/rally.helper.test.ts
@@ -217,6 +217,27 @@ describe("rally.helper.ts", () => {
 
       expect(result.game.teams.home.stats[0]!.rotation).toBe(0);
     });
+
+    it("should credit no one when the rally names no player", () => {
+      const mockGame = createMockGame();
+      // A guest on the roster carries a null id, the same value a rally with
+      // no named player stores.
+      mockGame.teams.home.players[0]!.id = null as unknown as string;
+      const unnamed = {
+        ...mockRally,
+        home: {
+          ...mockRally.home,
+          player: { id: null as unknown as string, zone: 0 },
+        },
+      };
+
+      const result = createRallyHelper(mockParams, unnamed, mockGame);
+
+      expect(
+        result.game.teams.home.players[0]!.stats[0]![M.ATTACK].success,
+      ).toBe(0);
+      expect(result.game.teams.home.stats[0]![M.ATTACK].success).toBe(1);
+    });
   });
 
   describe("updateRallyOptimistic", () => {

--- a/src/lib/features/game/helpers/optimistic/test/rally.helper.test.ts
+++ b/src/lib/features/game/helpers/optimistic/test/rally.helper.test.ts
@@ -220,8 +220,8 @@ describe("rally.helper.ts", () => {
 
     it("should credit no one when the rally names no player", () => {
       const mockGame = createMockGame();
-      // A guest on the roster carries a null id, the same value a rally with
-      // no named player stores.
+      // A squad member stored without an id carries the same value a rally
+      // with no named player stores.
       mockGame.teams.home.players[0]!.id = null as unknown as string;
       const unnamed = {
         ...mockRally,

--- a/src/lib/features/game/helpers/optimistic/test/rally.helper.test.ts
+++ b/src/lib/features/game/helpers/optimistic/test/rally.helper.test.ts
@@ -415,7 +415,7 @@ describe("rally.helper.ts", () => {
           mockGame,
         );
 
-        expect(result.phase.inProgress).toBe(true);
+        expect(result.phase.isSetInProgress).toBe(true);
         expect(result.phase.isSetPoint).toBe(false);
         expect(result.game.sets[0]!.win).toBeFalsy(); // 不應該設定勝負
       });
@@ -436,7 +436,7 @@ describe("rally.helper.ts", () => {
           mockGame,
         );
 
-        expect(result.phase.inProgress).toBe(false);
+        expect(result.phase.isSetInProgress).toBe(false);
         expect(result.game.sets[0]!.win).toBe(true); // 主隊贏了這局
       });
 
@@ -456,7 +456,7 @@ describe("rally.helper.ts", () => {
           mockGame,
         );
 
-        expect(result.phase.inProgress).toBe(false);
+        expect(result.phase.isSetInProgress).toBe(false);
         expect(result.game.sets[0]!.win).toBe(false); // 客隊贏了這局
       });
 
@@ -476,7 +476,7 @@ describe("rally.helper.ts", () => {
           mockGame,
         );
 
-        expect(result.phase.inProgress).toBe(true);
+        expect(result.phase.isSetInProgress).toBe(true);
         expect(result.phase.isSetPoint).toBe(true);
       });
 
@@ -511,7 +511,7 @@ describe("rally.helper.ts", () => {
           mockGame,
         );
 
-        expect(result.phase.inProgress).toBe(false);
+        expect(result.phase.isSetInProgress).toBe(false);
         expect(result.game.sets[4]!.win).toBe(true); // 主隊贏了決勝局
       });
     });
@@ -547,7 +547,7 @@ describe("rally.helper.ts", () => {
           mockGame,
         );
 
-        expect(result.phase.inProgress).toBe(false);
+        expect(result.phase.isSetInProgress).toBe(false);
         expect(result.game.sets[2]!.win).toBe(true);
         expect(result.game.win).toBe(true); // 主隊贏了比賽
       });
@@ -584,7 +584,7 @@ describe("rally.helper.ts", () => {
           mockGame,
         );
 
-        expect(result.phase.inProgress).toBe(false);
+        expect(result.phase.isSetInProgress).toBe(false);
         expect(result.game.sets[4]!.win).toBe(false);
         expect(result.game.win).toBe(false); // 客隊贏了比賽
       });
@@ -620,7 +620,7 @@ describe("rally.helper.ts", () => {
           mockGame,
         );
 
-        expect(result.phase.inProgress).toBe(true);
+        expect(result.phase.isSetInProgress).toBe(true);
         expect(result.game.win).toBeNull(); // 比賽還沒結束
       });
     });
@@ -657,7 +657,7 @@ describe("rally.helper.ts", () => {
           mockGame,
         );
 
-        expect(result.phase.inProgress).toBe(false);
+        expect(result.phase.isSetInProgress).toBe(false);
         expect(result.phase.isSetPoint).toBe(false);
         expect(result.game.sets[0]!.win).toBe(false);
       });

--- a/src/lib/features/game/helpers/queries/game-phase.helper.ts
+++ b/src/lib/features/game/helpers/queries/game-phase.helper.ts
@@ -12,14 +12,15 @@ export const gamePhaseHelper = (
   // To calculate the point to win the set
   const isDecidingSet = setIndex === game.info.scoring.setCount - 1;
   const point = isDecidingSet ? game.info.scoring.decidingSetPoints : 25;
-  const rally = getPreviousRally(game.sets[setIndex]?.entries, entryIndex);
+  const set = game.sets[setIndex];
+  const rally = getPreviousRally(set?.entries, entryIndex);
 
-  // In the first set, though there is no entries recorded yet,
-  // the game is `inProgress` if `entries` of the first set has been created
-  if (!rally) {
-    if (game?.sets[0]?.entries) return { inProgress: true, isSetPoint: false };
-    return { inProgress: false, isSetPoint: false };
-  }
+  // No rally to judge yet, so the set's own existence is the answer: a set that
+  // has been created is being played even with an empty `entries`, and one that
+  // has not must not report `inProgress` — the caller would render the
+  // recording court over a set the server has no row for, and every rally
+  // submitted from it is rejected.
+  if (!rally) return { inProgress: !!set, isSetPoint: false };
 
   const { home, away } = rally;
   // Game is in progress if both scores are less than point - 1

--- a/src/lib/features/game/helpers/queries/set-phase.helper.ts
+++ b/src/lib/features/game/helpers/queries/set-phase.helper.ts
@@ -1,12 +1,12 @@
 import { getPreviousRally } from "@/lib/features/game/helpers";
 import type { GameView } from "@/lib/features/game/types";
 
-export const gamePhaseHelper = (
+export const getSetPhase = (
   game: GameView,
   setIndex: number,
   entryIndex: number,
 ): {
-  inProgress: boolean;
+  isSetInProgress: boolean;
   isSetPoint: boolean;
 } => {
   // To calculate the point to win the set
@@ -15,24 +15,21 @@ export const gamePhaseHelper = (
   const set = game.sets[setIndex];
   const rally = getPreviousRally(set?.entries, entryIndex);
 
-  // No rally to judge yet, so the set's own existence is the answer: a set that
-  // has been created is being played even with an empty `entries`, and one that
-  // has not must not report `inProgress` — the caller would render the
-  // recording court over a set the server has no row for, and every rally
-  // submitted from it is rejected.
-  if (!rally) return { inProgress: !!set, isSetPoint: false };
+  // Nothing recorded yet: a set that exists is being played, and one that does
+  // not would otherwise render a recording court that rejects every rally.
+  if (!rally) return { isSetInProgress: !!set, isSetPoint: false };
 
   const { home, away } = rally;
-  // Game is in progress if both scores are less than point - 1
+  // The set is in progress while both scores are below the last point
   if (home.score < point - 1 && away.score < point - 1)
-    return { inProgress: true, isSetPoint: false };
+    return { isSetInProgress: true, isSetPoint: false };
 
   // Set point if one side's score is point - 1 and leading by at least 1 point
   if (
     (home.score === point - 1 && home.score > away.score) ||
     (away.score === point - 1 && away.score > home.score)
   )
-    return { inProgress: true, isSetPoint: true };
+    return { isSetInProgress: true, isSetPoint: true };
 
   // Set point if both scores are >= point - 1 and one side is leading by 1 point
   if (
@@ -40,14 +37,14 @@ export const gamePhaseHelper = (
     away.score >= point - 1 &&
     (home.score - away.score === 1 || away.score - home.score === 1)
   )
-    return { inProgress: true, isSetPoint: true };
+    return { isSetInProgress: true, isSetPoint: true };
 
-  // Game over if one side's score is >= point and leading by at least 2 points
+  // The set is over once one side reaches the point total and leads by 2
   if (home.score >= point && home.score - away.score >= 2)
-    return { inProgress: false, isSetPoint: false };
+    return { isSetInProgress: false, isSetPoint: false };
   if (away.score >= point && away.score - home.score >= 2)
-    return { inProgress: false, isSetPoint: false };
+    return { isSetInProgress: false, isSetPoint: false };
 
-  // Otherwise, the game is still in progress
-  return { inProgress: true, isSetPoint: false };
+  // Otherwise the set is still being played
+  return { isSetInProgress: true, isSetPoint: false };
 };

--- a/src/lib/features/game/helpers/queries/tests/game-phase.helper.test.ts
+++ b/src/lib/features/game/helpers/queries/tests/game-phase.helper.test.ts
@@ -25,6 +25,28 @@ describe("gamePhaseHelper", () => {
     expect(result).toEqual({ inProgress: false, isSetPoint: false });
   });
 
+  test("should not report in progress for a set that was never created", () => {
+    const mockGame = {
+      sets: [{ entries: [] }],
+      info: { scoring: { setCount: 5, decidingSetPoints: 15 } },
+    } as unknown as GameView;
+
+    const result = gamePhaseHelper(mockGame, 1, 0);
+
+    expect(result).toEqual({ inProgress: false, isSetPoint: false });
+  });
+
+  test("should return in progress for a later set with no entries yet", () => {
+    const mockGame = {
+      sets: [{ entries: [] }, { entries: [] }],
+      info: { scoring: { setCount: 5, decidingSetPoints: 15 } },
+    } as unknown as GameView;
+
+    const result = gamePhaseHelper(mockGame, 1, 0);
+
+    expect(result).toEqual({ inProgress: true, isSetPoint: false });
+  });
+
   test("should indicate game in progress when both scores are below set point", () => {
     const mockGame = {
       sets: [

--- a/src/lib/features/game/helpers/queries/tests/set-phase.helper.test.ts
+++ b/src/lib/features/game/helpers/queries/tests/set-phase.helper.test.ts
@@ -1,17 +1,17 @@
 import { EntryType, MoveType } from "@/entities/game";
-import { gamePhaseHelper } from "@/lib/features/game/helpers";
+import { getSetPhase } from "@/lib/features/game/helpers";
 import type { GameView } from "@/lib/features/game/types";
 
-describe("gamePhaseHelper", () => {
+describe("getSetPhase", () => {
   test("should return in progress when no entries exist but first set is created", () => {
     const mockGame = {
       sets: [{ entries: [] }],
       info: { scoring: { setCount: 5, decidingSetPoints: 15 } },
     } as unknown as GameView;
 
-    const result = gamePhaseHelper(mockGame, 0, 0);
+    const result = getSetPhase(mockGame, 0, 0);
 
-    expect(result).toEqual({ inProgress: true, isSetPoint: false });
+    expect(result).toEqual({ isSetInProgress: true, isSetPoint: false });
   });
 
   test("should return game not started when no sets exist", () => {
@@ -20,9 +20,9 @@ describe("gamePhaseHelper", () => {
       info: { scoring: { setCount: 5, decidingSetPoints: 15 } },
     } as unknown as GameView;
 
-    const result = gamePhaseHelper(mockGame, 0, 0);
+    const result = getSetPhase(mockGame, 0, 0);
 
-    expect(result).toEqual({ inProgress: false, isSetPoint: false });
+    expect(result).toEqual({ isSetInProgress: false, isSetPoint: false });
   });
 
   test("should not report in progress for a set that was never created", () => {
@@ -31,9 +31,9 @@ describe("gamePhaseHelper", () => {
       info: { scoring: { setCount: 5, decidingSetPoints: 15 } },
     } as unknown as GameView;
 
-    const result = gamePhaseHelper(mockGame, 1, 0);
+    const result = getSetPhase(mockGame, 1, 0);
 
-    expect(result).toEqual({ inProgress: false, isSetPoint: false });
+    expect(result).toEqual({ isSetInProgress: false, isSetPoint: false });
   });
 
   test("should return in progress for a later set with no entries yet", () => {
@@ -42,9 +42,9 @@ describe("gamePhaseHelper", () => {
       info: { scoring: { setCount: 5, decidingSetPoints: 15 } },
     } as unknown as GameView;
 
-    const result = gamePhaseHelper(mockGame, 1, 0);
+    const result = getSetPhase(mockGame, 1, 0);
 
-    expect(result).toEqual({ inProgress: true, isSetPoint: false });
+    expect(result).toEqual({ isSetInProgress: true, isSetPoint: false });
   });
 
   test("should indicate game in progress when both scores are below set point", () => {
@@ -64,9 +64,9 @@ describe("gamePhaseHelper", () => {
       info: { scoring: { setCount: 5, decidingSetPoints: 15 } },
     } as unknown as GameView;
 
-    const result = gamePhaseHelper(mockGame, 0, 1);
+    const result = getSetPhase(mockGame, 0, 1);
 
-    expect(result).toEqual({ inProgress: true, isSetPoint: false });
+    expect(result).toEqual({ isSetInProgress: true, isSetPoint: false });
   });
 
   test("should indicate set point when one team reaches 24 and leads", () => {
@@ -86,9 +86,9 @@ describe("gamePhaseHelper", () => {
       info: { scoring: { setCount: 5, decidingSetPoints: 15 } },
     } as unknown as GameView;
 
-    const result = gamePhaseHelper(mockGame, 0, 1);
+    const result = getSetPhase(mockGame, 0, 1);
 
-    expect(result).toEqual({ inProgress: true, isSetPoint: true });
+    expect(result).toEqual({ isSetInProgress: true, isSetPoint: true });
   });
 
   test("should indicate set point in deuce when scores are beyond 24", () => {
@@ -108,9 +108,9 @@ describe("gamePhaseHelper", () => {
       info: { scoring: { setCount: 5, decidingSetPoints: 15 } },
     } as unknown as GameView;
 
-    const result = gamePhaseHelper(mockGame, 0, 1);
+    const result = getSetPhase(mockGame, 0, 1);
 
-    expect(result).toEqual({ inProgress: true, isSetPoint: true });
+    expect(result).toEqual({ isSetInProgress: true, isSetPoint: true });
   });
 
   test("should indicate game over when one team wins by 2 points", () => {
@@ -130,9 +130,9 @@ describe("gamePhaseHelper", () => {
       info: { scoring: { setCount: 5, decidingSetPoints: 15 } },
     } as unknown as GameView;
 
-    const result = gamePhaseHelper(mockGame, 0, 1);
+    const result = getSetPhase(mockGame, 0, 1);
 
-    expect(result).toEqual({ inProgress: false, isSetPoint: false });
+    expect(result).toEqual({ isSetInProgress: false, isSetPoint: false });
   });
 
   test("should use different winning points in deciding set", () => {
@@ -153,8 +153,8 @@ describe("gamePhaseHelper", () => {
       info: { scoring: { setCount: 3, decidingSetPoints: 15 } },
     } as unknown as GameView;
 
-    const result = gamePhaseHelper(mockGame, 2, 1); // Last set (index 4)
+    const result = getSetPhase(mockGame, 2, 1); // Last set (index 4)
 
-    expect(result).toEqual({ inProgress: true, isSetPoint: true });
+    expect(result).toEqual({ isSetInProgress: true, isSetPoint: true });
   });
 });

--- a/src/lib/features/game/hooks/use-lineup.ts
+++ b/src/lib/features/game/hooks/use-lineup.ts
@@ -8,10 +8,10 @@ export const useLineup = (
   setIndex: number,
   status: ReduxStatus,
 ) => {
-  const { entryIndex, isServing, inProgress } = status;
+  const { entryIndex, isServing, isSetInProgress } = status;
   const { game } = useGame(gameId);
 
-  if (!inProgress || !game) return { starting: [], liberos: [] };
+  if (!isSetInProgress || !game) return { starting: [], liberos: [] };
 
   const set = game.sets[setIndex];
   if (!set) return { starting: [], liberos: [] };

--- a/src/lib/features/game/types.ts
+++ b/src/lib/features/game/types.ts
@@ -289,7 +289,7 @@ export type ReduxStatus = {
   };
   entryIndex: number;
   isServing: boolean;
-  inProgress: boolean;
+  isSetInProgress: boolean;
   isSetPoint: boolean;
   panel: "home" | "away" | "substitutes";
 };

--- a/test/integration/game-rally-from-created-game.itest.ts
+++ b/test/integration/game-rally-from-created-game.itest.ts
@@ -1,0 +1,101 @@
+import { MoveType } from "@/entities/game";
+import type { GameRepositoryImpl } from "@/infrastructure/db/repositories/game.repository.mongo";
+import { container } from "@/infrastructure/di/inversify.config";
+import { TYPES } from "@/infrastructure/di/types";
+import { POST as createGame } from "@/app/api/games/route";
+import { POST as createSet } from "@/app/api/games/[gameId]/sets/route";
+import { POST as createRally } from "@/app/api/games/[gameId]/sets/rallies/route";
+import { NextRequest } from "next/server";
+import { useFakeAuth } from "./support/auth";
+import { callRoute } from "./support/request";
+import { lineupFor, oid } from "./support/seed";
+
+const options = { serve: "home", time: { start: "10:00", end: "" } };
+
+/** The exact body `NewGameForm.createGame` sends. */
+const newGameBody = (teamId: string, playerIds: string[]) => ({
+  info: {
+    name: "Test Match",
+    number: 1,
+    phase: 0,
+    division: 0,
+    category: 0,
+    teams: { home: { name: "Home" }, away: { name: "Away" } },
+    scoring: { setCount: 3, decidingSetPoints: 15 },
+    location: { city: "", hall: "" },
+    time: { date: new Date().toISOString(), start: "", end: "" },
+    weather: { temperature: "" },
+  },
+  teams: {
+    home: {
+      id: teamId,
+      name: "Home",
+      // NewGameForm sends {id, name, number, list} — no `stats` key.
+      players: playerIds.map((id, i) => ({
+        id,
+        name: `Player ${i + 1}`,
+        number: i + 1,
+        list: i < 6 ? "starting" : "substitutes",
+      })),
+      lineup: lineupFor(playerIds),
+    },
+    away: { name: "Away" },
+  },
+});
+
+describe("real recording flow: create game -> create set 0 -> first rally", () => {
+  beforeEach(() => useFakeAuth());
+
+  const repo = () => container.get<GameRepositoryImpl>(TYPES.GameRepository);
+
+  it("records the first rally of a game created through POST /api/games", async () => {
+    const teamId = oid();
+    const playerIds = Array.from({ length: 8 }, oid);
+
+    const res = await createGame(
+      new NextRequest(`http://localhost/api/games?ti=${teamId}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(newGameBody(teamId, playerIds)),
+      }),
+    );
+    expect(res.status).toBe(201);
+    const { id: gameId } = (await res.json()) as { id: string };
+
+    // The set-options panel submits the lineup it read back off the game.
+    const persisted = await repo().findById(gameId);
+    const setRes = await callRoute(createSet, {
+      gameId,
+      method: "POST",
+      query: { si: 0 },
+      body: { lineup: persisted!.teams.home.lineup, options },
+    });
+    expect(setRes.status).toBe(201);
+
+    // The entry draft Redux actually submits: the home side carries the tapped
+    // player, the away side keeps the initial-state placeholder `id: ""`.
+    const draft = {
+      win: true,
+      home: {
+        score: 1,
+        type: MoveType.ATTACK,
+        num: 0,
+        player: { id: playerIds[0], zone: 4 },
+      },
+      away: {
+        score: 0,
+        type: MoveType.ATTACK,
+        num: 1,
+        player: { id: "", zone: 0 },
+      },
+    };
+
+    const rallyRes = await callRoute(createRally, {
+      gameId,
+      method: "POST",
+      query: { si: 0, ei: 0 },
+      body: draft,
+    });
+    expect(rallyRes.status).toBe(200);
+  });
+});

--- a/test/integration/game-rally.itest.ts
+++ b/test/integration/game-rally.itest.ts
@@ -22,9 +22,9 @@ describe("POST /api/games/:id/sets/rallies", () => {
 
   beforeEach(async () => {
     useFakeAuth();
-    // A guest player on the roster is the real-world trigger for the 404:
-    // create-set used to crash on its null id, so the set never persisted.
-    seeded = await seedGame({ includeGuest: true });
+    // A null roster id is not what broke rally recording, but create-set walks
+    // the whole squad and must not throw on one.
+    seeded = await seedGame({ includeNullIdPlayer: true });
   });
 
   const repo = () => container.get<GameRepositoryImpl>(TYPES.GameRepository);

--- a/test/integration/support/seed.ts
+++ b/test/integration/support/seed.ts
@@ -6,7 +6,7 @@ import { container } from "@/infrastructure/di/inversify.config";
 import { TYPES } from "@/infrastructure/di/types";
 import { Types } from "mongoose";
 
-const oid = () => new Types.ObjectId().toString();
+export const oid = () => new Types.ObjectId().toString();
 
 const emptyTeam = (
   name: string,

--- a/test/integration/support/seed.ts
+++ b/test/integration/support/seed.ts
@@ -46,8 +46,8 @@ export interface SeededGame {
 
 /** Persist a minimal game (home team with 6 players, no sets) for reuse. */
 export const seedGame = async ({
-  includeGuest = false,
-}: { includeGuest?: boolean } = {}): Promise<SeededGame> => {
+  includeNullIdPlayer = false,
+}: { includeNullIdPlayer?: boolean } = {}): Promise<SeededGame> => {
   const repo = container.get<IGameRepository>(TYPES.GameRepository);
   const teamId = oid();
   const playerIds = Array.from({ length: 6 }, oid);
@@ -57,12 +57,13 @@ export const seedGame = async ({
     number: i + 1,
     stats: [],
   }));
-  // Guest players carry no linked account: their persisted playerId is null,
-  // which round-trips to a null domain id.
-  if (includeGuest) {
+  // Stands in for a squad member stored through the unvalidated create-game
+  // body: no product path writes a null roster id, but the readers must not
+  // throw on one.
+  if (includeNullIdPlayer) {
     players.push({
       id: null as unknown as string,
-      name: "Guest",
+      name: "Unlinked",
       number: 99,
       stats: [],
     });


### PR DESCRIPTION
Fixes the rally 404 reported in Linear [ATE-92](https://linear.app/asatelier/issue/ATE-92). The root cause recorded on that issue was disproven: the 404 was never `SET_NOT_FOUND`, and the set was in the database the whole time.

## What was actually happening

Production errors are compiled away (`removeConsole` strips `console.error`, which `withErrorHandler` depends on), so the failure was diagnosed against a dev server pointed at the same Atlas data. That produced the decisive line:

```
{"level":"warn","code":"NOT_FOUND","reason":"RESOURCE_NOT_FOUND",
 "message":"Cast to embedded failed for value \"{...entries:[{type:'Rally',...}]...}\"
   (type Object) at path \"sets\" because of \"CastError\"",
 "path":"/api/games/<id>/sets/rallies","method":"POST"}
```

A rally's away side carries the Redux placeholder `player.id: ""` — a point won against the opponent has no player to name. The repository write mapper collapsed absence with `id ?? null`, which keeps `""`. An empty string is not a castable ObjectId, and because `sets` is a subdocument array, one bad leaf makes Mongoose reject the entire path, so no rally could ever be saved. `translateRepositoryError` then reported the CastError as a 404, which is what made it look like a missing set for two weeks.

Verified live: two rallies posted 200 against the same game and the same data that reproduced the 404.

## Commits

| Commit | Change |
| --- | --- |
| `fix(game): store an empty player reference as null` | Every write mapper that turns a domain id into a stored reference now collapses absence the same way, substitution `players.in/out` included. Adds an integration test that drives the real entry sequence — game created through `POST /api/games` with the payload the new-game form sends, rally carrying the draft shape Redux submits. The existing coverage sent a rally with no `player` key at all, which skips the mapper branch entirely. |
| `fix(api): report an unstorable write payload as 400, not 404` | Only an uncastable `_id` is a lookup miss. A cast failure on any other path is a value the database cannot store. |
| `fix(game): judge set phase by the set being recorded` | The phase helper decided "in progress" from whether set 0 existed rather than the set being viewed, so a set that does not exist rendered a recording court that rejected every rally sent from it. Interval also offered `setIndex + 1` as the next set, which diverges from `sets.length` as soon as the viewed set is not the last. |
| `refactor(game): name the set-scoped phase flag and helper for the set` | `inProgress` is a match-level word carrying a set-level fact; `game.win` is the flag that really is match-level. `gamePhaseHelper` becomes `getSetPhase`, matching the `get*` convention of every other query helper, and its file moves with it. The preview hook's own `inProgress` (whether there is a draft to render) becomes `hasPreview`. |
| `refactor(game): describe null player ids by what produces them` | An earlier commit chasing this 404 asserted that a null roster id belongs to a "guest player" and guarded three call sites on that basis. No guest feature exists, and the planned design gives a guest a generated id rather than none. Every guard stays — an unfilled lineup slot legitimately holds null, and a roster id can still arrive null through the unvalidated create-game body — only the explanation changes. |

## Scope note

`Interval`'s next-set index is not part of the reported bug. It became reachable through the set-phase fix: once a set that does not exist falls through to the interval screen, `setIndex + 1` would skip a set. It is listed as a user-visible fix in the changeset.

## Verification

`pnpm verify:all` passes in full — format, workflow checks, `typecheck:strict`, lint, 801 tests across the backend, frontend, and integration projects, production build, `assert-sw`, and the Blueprint build. `/simplify` and a two-axis `code-review` both ran to a fixed point; accepted findings are folded into the commits above.

## Follow-ups

Deliberately out of scope, to be filed after merge:

- Emit `null` rather than `""` for an absent player id at the Redux layer, so the value never exists.
- Add request schema validation to `POST /api/games` — `PATCH /api/teams/:id/lineups` already has one, and its `objectId` is nullable while rejecting `""`, which is exactly the shape the game routes lack.
- Move repository writes from whole-document `$set` to targeted positional operators, so one invalid leaf cannot fail an entire match.
- Enforce that a set lineup is complete; nothing currently requires six players on court.
- Preserve `console.error` in production builds, which also blocks error tracking in ATE-103.

---

## 摘要（zh-tw）

線上送出 rally 一律回 404，票上記載的根因（`SET_NOT_FOUND`，set 未持久化）不成立——set 一直都在資料庫裡。

真正原因是 rally 的對手側帶著 Redux 的佔位值 `player.id: ""`（對手得分沒有球員可指定），而 repository 的寫入轉換用 `id ?? null` 收斂，空字串被原樣保留。空字串不是合法的 ObjectId，加上 `sets` 是 subdocument array，任一 leaf cast 失敗會讓整個路徑寫入被拒，所以沒有任何一顆球存得進去。`translateRepositoryError` 又把 CastError 翻成 404，這正是它被誤判成「找不到 set」兩週的原因。

production 的 `console.error` 被編譯移除，因此改用連到同一份 Atlas 資料的 dev server 診斷，取得決定性的錯誤行；修正後在同一場比賽、同一份資料上實測兩顆 rally 皆為 200。

除根因外一併修正：CastError 的 400/404 分界、局階段判斷改看當前該局而非第 0 局、set 層級旗標與 helper 的命名、以及一批建立在已被推翻的推論上的「guest 球員」註解（守衛全部保留，只更正說明）。所有 deferred 項目列於上方 Follow-ups。
