### PR TITLE
fix(build): keep console.error in production builds

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -30,7 +30,8 @@ const nextConfig = {
     ],
   },
   compiler: {
-    removeConsole: process.env.NODE_ENV === "production",
+    removeConsole:
+      process.env.NODE_ENV === "production" ? { exclude: ["error"] } : false,
     reactRemoveProperties: removeProperties,
   },
 };


### PR DESCRIPTION
## What

`removeConsole: true` strips every console method from application code in production builds, including the `console.error` that `withErrorHandler` relies on to emit its structured error payload. Production server errors were therefore silent, and a domain 404 raised by a use case was indistinguishable from a Next routing 404 in the platform logs.

Excluding `error` restores that signal while still dropping `log`/`warn`/`debug` noise.

```js
removeConsole:
  process.env.NODE_ENV === "production" ? { exclude: ["error"] } : false,
```

## Why now

This is the direct reason the rally-404 bug (ATE-92) went misdiagnosed for two weeks — the structured error payload existed but never reached the platform logs. It is also a prerequisite for any error tracking work: an error reporter wired up on top of a build that strips `console.error` still receives nothing.

## Scope notes

- One line in `next.config.js`. No application code, no behavior change for users.
- **No changeset**: zero user-visible impact (build configuration / operator-visible logging only), which is the documented exemption in `.claude/skills/writing-changesets`.
- **No Blueprint Change**: this predates a lifecycle Change and there is no durable knowledge to promote. It is the same lightweight-path gap tracked in ATE-109.
- The branch name carries the `ate-92` prefix because the commit was authored during that investigation; the tracked issue is ATE-103.

## Verification

`pnpm verify:all` passes locally (format, workflow checks, strict typecheck, lint, tests, `pnpm build`, service-worker assertion, blueprint build).

Refs ATE-103

---

## 摘要（zh-TW）

`removeConsole: true` 會在 production build 移除所有 console 方法，連 `withErrorHandler` 用來輸出結構化錯誤內容的 `console.error` 也一併被移除，導致線上伺服器錯誤完全靜默，use case 拋出的領域 404 在平台日誌中與 Next 路由 404 無法區分。改為排除 `error` 後恢復此訊號，同時仍濾掉 `log`/`warn`/`debug` 噪音。

這正是 ATE-92（rally 送出一律 404）被誤診兩週的直接原因，也是後續接上錯誤追蹤的前提——在會 strip `console.error` 的 build 上接錯誤回報器仍然收不到任何東西。

僅動 `next.config.js` 一行，無使用者可見的行為變更，因此依 changeset 規範豁免不附 changeset；同理無 Blueprint Change 可歸檔（即 ATE-109 追蹤的輕量路徑缺口）。本地 `pnpm verify:all` 全綠。
