### PR TITLE
fix(blueprint): navigate in-app links without a full page load

### DIFF
--- a/blueprint/content/design-system/color/index.tsx
+++ b/blueprint/content/design-system/color/index.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+
 import { SwatchGrid, type TokenInfo } from "../_shared";
 
 // Token groups only name the CSS custom property and its role — the rendered
@@ -79,8 +81,8 @@ export default function ColorPage() {
       <p>
         Three distinct background layers, ordered by elevation. This is the
         heart of the <code>elevation-depth-system</code> change — see{" "}
-        <a href="/design-system/elevation-depth">Elevation &amp; Depth</a> for
-        the layering rules and the overlay-replaces-ring model.
+        <Link href="/design-system/elevation-depth">Elevation &amp; Depth</Link>{" "}
+        for the layering rules and the overlay-replaces-ring model.
       </p>
       <SwatchGrid tokens={surface} />
 

--- a/blueprint/content/design-system/elevation-depth/index.tsx
+++ b/blueprint/content/design-system/elevation-depth/index.tsx
@@ -3,6 +3,8 @@
 // .light/.dark scopes. The open Drawer-layer question and its interactive
 // comparison live in the elevation-depth-system change's design page.
 
+import Link from "next/link";
+
 const layers = [
   {
     name: "Level 0 · Page",
@@ -122,9 +124,9 @@ export default function ElevationDepthPage() {
         <code>bg-card</code> — the scrim separates it from the page, and the
         Drawer peek stays continuous with the page&apos;s card surfaces. The
         interactive comparison that settled this lives in the{" "}
-        <a href="/changes/archive/2026-07-16-elevation-depth-system/design">
+        <Link href="/changes/archive/2026-07-16-elevation-depth-system/design">
           elevation-depth-system change&apos;s design page
-        </a>
+        </Link>
         .
       </p>
 

--- a/blueprint/content/design-system/index.tsx
+++ b/blueprint/content/design-system/index.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+
 import {
   Card,
   CardDescription,
@@ -59,7 +61,7 @@ export default function DesignSystemOverview() {
       <h2 id="sections">Sections</h2>
       <div className="mt-6 grid gap-4 sm:grid-cols-2">
         {sections.map((s) => (
-          <a
+          <Link
             key={s.href}
             href={s.href}
             className="block text-inherit no-underline"
@@ -70,7 +72,7 @@ export default function DesignSystemOverview() {
                 <CardDescription>{s.body}</CardDescription>
               </CardHeader>
             </Card>
-          </a>
+          </Link>
         ))}
       </div>
     </>

--- a/blueprint/src/components/ChangeCard.tsx
+++ b/blueprint/src/components/ChangeCard.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+
 import { Badge } from "@/components/ui/badge";
 import {
   Card,
@@ -97,9 +99,9 @@ export function ChangeCard({
 
   if (href) {
     return (
-      <a href={href} className="block text-inherit !no-underline">
+      <Link href={href} className="block text-inherit !no-underline">
         {inner}
-      </a>
+      </Link>
     );
   }
   return inner;

--- a/blueprint/src/components/ChangeOverview.tsx
+++ b/blueprint/src/components/ChangeOverview.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+
 import { Badge } from "@/components/ui/badge";
 import { Card } from "@/components/ui/card";
 import type { ChangeLifecycle } from "@/lib/change-types";
@@ -45,12 +47,12 @@ function StatusBadge({ status }: { status: Status }) {
 
 function ArtifactCard({ title, href }: Artifact) {
   return (
-    <a href={href} className="block text-inherit no-underline">
+    <Link href={href} className="block text-inherit no-underline">
       <Card className="flex-row items-center gap-2 border-l-4 border-l-primary px-4 py-3 text-sm font-medium transition-colors hover:bg-muted/50">
         {title}
         <span className="ml-auto text-xs text-muted-foreground">→</span>
       </Card>
-    </a>
+    </Link>
   );
 }
 


### PR DESCRIPTION
## Symptom

Collapse the Blueprint sidebar, then click through to another page: the sidebar comes back expanded. The same happens to any sidebar folder the reader had closed.

## Root cause

Not the folder logic. Blueprint rendered every internal link as a raw `<a href>` — the Change artifact cards, the Change cards in the catalog, and the design-system section cards. A raw anchor is a full document load, which tears down the React tree and rebuilds it from scratch.

Fumadocs holds both pieces of sidebar state in React state that nothing persists: `collapsed` in `SidebarProvider`, and each folder's `open` in `SidebarFolder`. A remount is therefore indistinguishable from a first visit, and both reset to their defaults.

Sidebar links never showed the bug because fumadocs renders those with `next/link`.

## Fix

Route the five remaining internal links through `next/link`. Blueprint had no `Link` import anywhere before this — every internal link was a hard navigation.

## Verification

Reproduced and confirmed against the dev server by marking `document.documentElement` before navigating: the marker is a soft-navigation detector, since a full load discards it.

| | before | after |
| --- | --- | --- |
| marker survives the click | no | yes |
| `#nd-sidebar[data-collapsed]` | flips back to `false` | stays `true` |

Checked on a Change Overview artifact card and a design-system section card. `pnpm verify:all` passes.

Sidebar state still resets when switching between the Changes / Features / Design System tabs, which is correct — those render different trees.

---

## 摘要

收合 blueprint 側邊欄後切換頁面，側邊欄會自己變回展開。原因不在資料夾展開邏輯，而是 blueprint 的站內連結全部是原生 `<a href>`——Change 的 artifact 卡片、目錄頁的 Change 卡片、design-system 的分區卡片都是。原生 anchor 會觸發整頁載入，React 樹整個重建，而 fumadocs 的側邊欄收合狀態（`SidebarProvider` 的 `collapsed` 與各資料夾的 `open`）純粹存在 React state 裡，重新掛載就等同第一次造訪，全部回到預設值。

側邊欄自己的連結不會發生，因為 fumadocs 用 `next/link` 渲染它們。修法是把剩下五個站內連結也改走 `next/link`——在此之前 blueprint 完全沒有任何 `Link` import。

驗證方式是在導覽前於 `document.documentElement` 標記，用它區分軟導覽與整頁載入：修正前標記消失且 `data-collapsed` 翻回 `false`，修正後標記存活且維持 `true`。

切換 Changes / Features / Design System 分頁時狀態仍會重設，那是正確的——它們渲染的是不同的樹。
