### PR TITLE
chore: check in the blueprint dev server launch config

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "blueprint",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["--filter", "blueprint", "dev", "--port", "3100"],
+      "port": 3100
+    }
+  ]
+}


### PR DESCRIPTION
## What

Checks in `.claude/launch.json`, the dev-server config that starts the Blueprint site on port 3100.

## Why separate from #372

`.claude/launch.json` is dev tooling, not part of the sidebar fix. #372 already had a green CI run, and appending an unrelated file would have discarded it and mixed two scopes into one squashed commit.

`.gitignore` excludes `.claude/settings.*` only — the rest of `.claude` (the skills) is already shared — so this file was untracked rather than ignored.

---

## 摘要

把 `.claude/launch.json` 納入版控。這是啟動 blueprint dev server（port 3100）的設定，診斷側邊欄缺陷時手動從 `package.json` 重建出來的，checked in 之後下次不必再猜。

單獨開 PR 而不併入 #372：它屬於開發工具而非該修正的一部分，#372 的 CI 已經是綠的，追加無關檔案會作廢那次結果，也會讓一顆 squash commit 混進兩種範圍。`.gitignore` 只排除 `.claude/settings.*`，其餘 `.claude` 內容（skills）本來就是共享的，所以這個檔案是未追蹤而非被忽略。
