### PR TITLE
refactor(workflow): make the Blueprint contract enforceable

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -174,13 +174,20 @@ Apply is the same repository procedure in both execution modes:
    verification;
 8. continue until no eligible pending slice remains.
 
+The commit body is the canonical slice-to-commit mapping. It travels with the commit through
+rebases, which rewrite hashes but preserve bodies, so `git log --grep` reconstructs the mapping at
+any time. Blueprint artifacts therefore reference slices by stable ID and must not pin commit
+hashes: a pinned hash is a copy of a fact the commit already states, and every history rewrite
+silently invalidates it. Already-archived Changes keep the records they were accepted with; this
+rule governs Changes still in flight.
+
 The same-commit rule applies once this contract exists on the branch's base. When this workflow is
 first adopted around work that was already committed, or when existing commits are surgically
 replayed onto a fresh base, do not rewrite otherwise valid history solely to fabricate compliance.
 Before Pre-PR review completes and before developer acceptance, Blueprint Review must instead
-identify the bootstrap deviation and provide a durable mapping from every completed slice to its
-actual implementation commits and verification. This exception ends after the workflow contract
-lands on the base branch.
+identify the bootstrap deviation and describe, per completed slice, what was delivered and how it
+was verified. This exception ends after the workflow contract lands on the base branch. It does not
+license pinning commit hashes, which stay out of Blueprint artifacts for the reason given above.
 
 Verification failures remain inside Apply. Diagnose whether the implementation is wrong or the
 approved design is no longer viable. Fix implementation defects without creating a separate stage.
@@ -211,7 +218,8 @@ After all slices complete:
 4. fix every accepted finding, rerun affected targeted checks and `pnpm verify:all`, then repeat
    independent review until both axes reach a fixed point;
 5. update Blueprint Review after each round with actual delivery, verification, findings, fixes,
-   plan-versus-actual differences, residual risks, and follow-ups; and
+   plan-versus-actual differences, residual risks, and follow-ups, identifying slices by stable ID
+   rather than by commit hash; and
 6. set the Change lifecycle to `awaiting-delivery-review`, notify the developer, and stop for
    acceptance of Blueprint Review.
 
@@ -330,6 +338,11 @@ back into the Change branch before final verification.
 
 Do not create a separate planning branch and do not merge proposal artifacts into `dev` before the
 Change is delivered. Push the Change branch when another session or Symphony must resume it.
+
+Merge a Change into `dev` with a merge commit. Squashing collapses the per-slice commits and
+discards the `Implements` and `Blueprint-Change` trailers that make delivery traceable, which is
+exactly the evidence Pre-PR review and Archive depend on. Squash only work that carries no slice
+history — a single-commit fix or a tooling change — and say so in the pull request.
 
 ## Execution modes
 

--- a/scripts/check-workflow.mjs
+++ b/scripts/check-workflow.mjs
@@ -53,6 +53,21 @@ const RETIRED_REFERENCE = ["spec", "loop"].join("-");
 const ACTIVE_ROOT_FILES = ["CLAUDE.md", "AGENTS.md", "package.json"];
 const ACTIVE_DIRECTORIES = [".github", "scripts"];
 const RETIRED_WORKFLOW_PATTERN = /^spectra-.*\.md$/;
+const BLUEPRINT_CHANGES = "blueprint/content/changes";
+const BLUEPRINT_LINK_SOURCES = ["blueprint/src", "blueprint/content"];
+const BLUEPRINT_LINK_EXTENSIONS = new Set([".tsx", ".mdx"]);
+const CHANGES_ROUTE = path.join(
+  "blueprint",
+  "src",
+  "app",
+  "(docs)",
+  "changes",
+  "[[...slug]]",
+  "page.tsx",
+);
+const ANCHOR_TAG = /<a(\s[^>]*)>/g;
+const EXTERNAL_HREF = /href=["'](?:#|https?:|mailto:|tel:)/;
+const DESIGN_MODULE_KEY = /"([^"]+)\/design":/g;
 
 async function validateContributorGuidance(root) {
   const contributorPath = path.join(root, "CONTRIBUTING.md");
@@ -324,6 +339,82 @@ async function activeReferenceFiles(root) {
   });
 }
 
+// A Change Overview renders change.json and the registered pages. Restating any
+// of that as MDX props reintroduces the hand-synchronised copies the
+// Implementation-slice contract removed.
+async function validateOverviewSource(root) {
+  const files = await listFiles(path.join(root, BLUEPRINT_CHANGES));
+  const diagnostics = [];
+
+  for (const filePath of files) {
+    if (path.basename(filePath) !== "index.mdx") continue;
+    const content = await readFile(filePath, "utf8");
+    if (!content.includes("<ChangeOverview")) continue;
+    diagnostics.push(
+      `${path.relative(root, filePath)} [blueprint-overview-source]: Overview metadata comes from change.json, not ChangeOverview props`,
+    );
+  }
+
+  return diagnostics;
+}
+
+// A raw anchor is a full document load, which discards the sidebar state
+// fumadocs keeps in React state. Internal links have to route through next/link.
+async function validateInternalLinks(root) {
+  const files = (
+    await Promise.all(
+      BLUEPRINT_LINK_SOURCES.map((relativePath) =>
+        listFiles(path.join(root, relativePath)),
+      ),
+    )
+  )
+    .flat()
+    .filter((filePath) =>
+      BLUEPRINT_LINK_EXTENSIONS.has(path.extname(filePath)),
+    );
+
+  const diagnostics = [];
+  for (const filePath of files) {
+    const content = await readFile(filePath, "utf8");
+    for (const [, attributes] of content.matchAll(ANCHOR_TAG)) {
+      if (!attributes.includes("href=")) continue;
+      if (EXTERNAL_HREF.test(attributes)) continue;
+      diagnostics.push(
+        `${path.relative(root, filePath)} [blueprint-internal-link]: use next/link so navigation keeps the sidebar state`,
+      );
+      break;
+    }
+  }
+
+  return diagnostics;
+}
+
+// The design module registry repeats each Change's directory. Until that
+// coupling goes away, name the mismatch instead of failing as a module
+// resolution error deep inside the bundler.
+async function validateDesignModules(root) {
+  const routePath = path.join(root, CHANGES_ROUTE);
+  if (!(await exists(routePath))) return [];
+
+  const route = await readFile(routePath, "utf8");
+  const diagnostics = [];
+  for (const [, changePath] of route.matchAll(DESIGN_MODULE_KEY)) {
+    const designPath = path.join(
+      root,
+      BLUEPRINT_CHANGES,
+      changePath,
+      "design.tsx",
+    );
+    if (!(await exists(designPath))) {
+      diagnostics.push(
+        `${CHANGES_ROUTE} [blueprint-design-module]: ${changePath}/design.tsx does not exist`,
+      );
+    }
+  }
+
+  return diagnostics;
+}
+
 export async function checkWorkflow(root = process.cwd()) {
   const diagnostics = [];
   const workflowPath = path.join(root, "WORKFLOW.md");
@@ -358,6 +449,9 @@ export async function checkWorkflow(root = process.cwd()) {
     }
   }
 
+  diagnostics.push(...(await validateOverviewSource(root)));
+  diagnostics.push(...(await validateInternalLinks(root)));
+  diagnostics.push(...(await validateDesignModules(root)));
   diagnostics.push(...(await validateSharedSkills(root)));
   diagnostics.push(...(await validateRetiredAuthorities(root)));
   diagnostics.push(...(await validateContributorGuidance(root)));

--- a/scripts/check-workflow.test.mjs
+++ b/scripts/check-workflow.test.mjs
@@ -191,3 +191,73 @@ test("reports an active retired harness reference", async () => {
     /scripts\/dispatch\.mjs.*retired/i,
   );
 });
+
+test("reports Overview metadata restated as MDX props", async () => {
+  assert.match(
+    (
+      await messages({
+        "blueprint/content/changes/in-progress/sample/index.mdx":
+          '---\ntitle: Overview\n---\n\n<ChangeOverview date="2026-08-08" />\n',
+      })
+    ).join("\n"),
+    /sample\/index\.mdx.*blueprint-overview-source/i,
+  );
+});
+
+test("accepts an Overview that carries narrative content only", async () => {
+  assert.deepEqual(
+    await messages({
+      "blueprint/content/changes/in-progress/sample/index.mdx":
+        "---\ntitle: Overview\n---\n\n## Context\n",
+    }),
+    [],
+  );
+});
+
+test("reports an internal link that bypasses the router", async () => {
+  assert.match(
+    (
+      await messages({
+        "blueprint/src/components/Sample.tsx":
+          'export const Sample = () => <a href="/changes">Changes</a>;\n',
+      })
+    ).join("\n"),
+    /Sample\.tsx.*blueprint-internal-link/i,
+  );
+});
+
+test("accepts external links and in-page anchors", async () => {
+  assert.deepEqual(
+    await messages({
+      "blueprint/src/components/Sample.tsx":
+        'export const Sample = () => <a href="https://volleybro.dev">Site</a>;\n',
+      "blueprint/content/design-system/index.mdx":
+        '<a href="#tokens">Tokens</a>\n',
+    }),
+    [],
+  );
+});
+
+test("reports a design module without its interactive design page", async () => {
+  assert.match(
+    (
+      await messages({
+        "blueprint/src/app/(docs)/changes/[[...slug]]/page.tsx":
+          'const designModules = {\n  "archive/moved-change/design": () => import("x"),\n};\n',
+      })
+    ).join("\n"),
+    /archive\/moved-change\/design\.tsx.*does not exist/i,
+  );
+});
+
+test("accepts a design module whose design page exists", async () => {
+  assert.deepEqual(
+    await messages({
+      "blueprint/src/app/(docs)/changes/[[...slug]]/page.tsx":
+        'const designModules = {\n  "archive/kept-change/design": () => import("x"),\n};\n',
+      "blueprint/content/changes/archive/kept-change/design.tsx":
+        "export default () => null;\n",
+    }),
+    [],
+  );
+});


### PR DESCRIPTION
## Why

Three clauses of the Blueprint contract existed only as prose in `WORKFLOW.md`, and all three had already been violated in practice — each found by a reader or by a confusing bundler error rather than by a check:

| Clause | How it failed before |
| --- | --- |
| Overview metadata comes from `change.json` | Hand-copied props drifted from the canonical file; one Change carried a dead artifact link, a missing page, and a second summary (#371) |
| Internal links go through the router | Every raw `<a href="/…">` was a full page load, silently resetting the sidebar state on every click (#372) |
| `designModules` tracks the Change directory | Moving a Change breaks the build as a module resolution error with no mention of the Change |

## What changed

Three validators in `scripts/check-workflow.mjs`, alongside the existing ones, so `pnpm verify` fails with a named cause. Each was proven against a real reintroduced regression, not only against fixtures.

The internal-link rule allows `http(s):`, `mailto:`, `tel:`, and `#` anchors; anything else has to be `next/link`.

## Review contract

`review.mdx` stops pinning commit hashes. The commit body already records which slice it implements, and it survives the rebases that rewrite hashes — so a pinned hash is a second copy of a fact the commit already states, and every history rewrite invalidates it silently. That is not hypothetical: rebasing `feat/game-positional-writes` onto #371 dangled all eight hashes in its review record. Blueprint artifacts now reference slices by stable ID, and `git log --grep` reconstructs the mapping on demand. Already-archived Changes keep the records they were accepted with.

Merging a Change now uses a merge commit for the same reason: squashing collapses the per-slice commits and discards the `Implements` / `Blueprint-Change` trailers the mapping is recovered from. Squash stays available for work with no slice history.

## Not included

No check for hashes in `review.mdx`. Distinguishing a commit hash from other hex in prose is guesswork, and the archived Changes legitimately contain some.

## Verification

`pnpm verify:all` passes; `pnpm test:workflow` is 19 tests, 6 of them new.

---

## 摘要

Blueprint 契約的三條規則原本只是 `WORKFLOW.md` 裡的散文，而且三條都已經被違反過——每一次都是靠人讀出來或靠一個看不出原因的 bundler 錯誤才發現。現在它們是 `scripts/check-workflow.mjs` 裡的三個 validator，回歸時 `pnpm verify` 會指名失敗原因。三條都用真實的回歸重現驗證過，不只有 fixture。

Review 契約不再釘 commit hash：commit body 本來就記錄了它實作哪一片，而且 rebase 會改寫 hash 但保留 body，所以釘 hash 是同一個事實的第二份副本，每次改寫歷史都會無聲失效——`feat/game-positional-writes` rebase 到 #371 之後八個 hash 全部指向不存在的物件，就是實例。改為以 slice ID 指稱，映射用 `git log --grep` 隨時重建。已封存的 Change 保留當初驗收的紀錄。

Change 合併改用 merge commit，理由相同：squash 會壓掉逐片 commit 與 `Implements` / `Blueprint-Change` trailer，而映射正是從那裡重建的。沒有切片歷史的工作仍可 squash。
