### PR TITLE
fix(blueprint): index only navigation files as content metadata

### DIFF
--- a/blueprint/source.config.ts
+++ b/blueprint/source.config.ts
@@ -1,11 +1,21 @@
 import { defineDocs, defineConfig } from "fumadocs-mdx/config";
 
+// A meta collection matches every JSON under its directory by default, which
+// would index each decision and implementation-slice record as navigation
+// metadata. Those records are read directly — by the slice loader and by MDX
+// imports — so restricting the collection keeps their directories out of the
+// page tree, where they would otherwise appear as empty folders and shadow the
+// sibling page of the same name.
+const metaFiles = { files: ["**/meta.json"] };
+
 export const { docs, meta } = defineDocs({
   dir: "content/changes",
+  meta: metaFiles,
 });
 
 export const { docs: featureDocs, meta: featureMeta } = defineDocs({
   dir: "content/features",
+  meta: metaFiles,
 });
 
 export default defineConfig();


### PR DESCRIPTION
## Root cause

A fumadocs `meta` collection matches every JSON file under its directory. All 32 decision and implementation-slice records were therefore being indexed as navigation metadata — visible in the generated source as `…/design/decisions/D1-….json?collection=meta`.

Because those directories held indexed content, they became page-tree folders, with two consequences:

- an empty **Decisions** folder in the Features sidebar that expands to nothing — one per capability, six of them
- `design/` shadowing its sibling `design.mdx`, so the **Design and Implementation pages of any Change carrying slices or decisions were absent from the page tree entirely**

The second one is why `changeArtifacts` had to read the breadcrumb tree rather than the source tree: `withDirectChangePages` was re-injecting pages that the shadowing had removed.

## Fix

Restrict both collections to `meta.json`. Nothing consumed these records through the loader — the slice loader reads them from disk with `readFile`, and decision records are ESM-imported by the pages that render them (`import d from "./decisions/D3-….json"`).

## Verification

- No `?collection=meta` entries for `decisions/` or `slices/` remain in the generated source
- All 10 Change Overviews render the same artifact set as before, including the two Changes that carry both `design/decisions/` and `implementation/slices/`; no dead links
- The Features sidebar no longer renders a Decisions folder
- `pnpm verify:all` passes

## Follow-up, not included

With the shadowing gone, `withDirectChangePages` in `changes-tree.ts` may now be dead. The Change that flattens the status directories rewrites that file anyway, so it is better assessed there than removed on a guess.

---

## 摘要

fumadocs 的 meta collection 預設吃該目錄底下**所有** JSON，所以 32 個 decision 與 implementation-slice 記錄全部被當成導覽 metadata 索引。那些目錄因此成為 page tree 的資料夾節點，造成兩個可見後果：Features 側邊欄出現點了沒反應的 "Decisions" 資料夾（每個能力一個，共六個），以及 `design/` 遮蔽同名的 `design.mdx`——凡是帶有 slices 或 decisions 的 Change，它的 Design 與 Implementation 頁根本不在樹上。

第二點正是 `changeArtifacts` 當初必須改讀 breadcrumb tree 的原因。

修法是把兩個 collection 限制在 `meta.json`。沒有任何東西透過 loader 消費那些記錄——slice 由 loader 以 `readFile` 讀取，decision 由渲染它們的頁面直接 ESM import。
